### PR TITLE
docs: Add publish_date to OpenAPI specfication for /bundles GET endpoint

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -87,6 +87,13 @@ parameters:
     type: integer
     default: 0
     minimum: 0
+  publish_date:
+    name: publish_date
+    description: "Filter bundles by their scheduled publication date. Accepts an optional datetime value and returns all bundles where the scheduled_at field matches the specified datetime."
+    in: query
+    required: false
+    type: string
+    format: date-time
   bundle_state:
     required: true
     name: bundle_state
@@ -117,6 +124,7 @@ paths:
       parameters:
         - $ref: "#/parameters/limit"
         - $ref: "#/parameters/offset"
+        - $ref: "#/parameters/publish_date"
       produces:
         - "application/json"
       responses:


### PR DESCRIPTION
### What

- Add `publish_date` parameter to the `GET /bundles` OpenAPI specification

### How to review

- Verify that the changes match the description in DIS-3299 
- Verify that the swagger file is still valid

### Who can review

Anyone
