### PR TITLE
Feature/amend get version error handling

### DIFF
--- a/apierrors/errors.go
+++ b/apierrors/errors.go
@@ -13,9 +13,10 @@ func (e ErrInvalidPatch) Error() string {
 
 // Response error descriptions
 var (
-	ErrorDescriptionMalformedRequest = "Unable to process request due to a malformed or invalid request body or query parameter"
-	ErrorDescriptionNotFound         = "The requested resource does not exist"
-	ErrorDescriptionInternalError    = "Failed to process the request due to an internal error"
+	ErrorDescriptionMalformedRequest  = "Unable to process request due to a malformed or invalid request body or query parameter"
+	ErrorDescriptionMissingParameters = "Unable to process request due to missing required parameters in the request body or query parameters"
+	ErrorDescriptionNotFound          = "The requested resource does not exist"
+	ErrorDescriptionInternalError     = "Failed to process the request due to an internal error"
 )
 
 var (

--- a/features/steps/bundle_component.go
+++ b/features/steps/bundle_component.go
@@ -170,7 +170,13 @@ func (c *BundleComponent) DoGetMongoDB(context.Context, config.MongoConfig) (sto
 func (c *BundleComponent) DoGetDatasetAPIClient(datasetAPIURL string) datasetAPISDK.Clienter {
 	datasetAPIClient := &datasetAPISDKMock.ClienterMock{
 		GetVersionFunc: func(ctx context.Context, headers datasetAPISDK.Headers, datasetID, editionID string, versionID string) (datasetAPIModels.Version, error) {
-			if datasetID == "fail-get-version" {
+			if datasetID == "dataset-not-found" {
+				return datasetAPIModels.Version{}, errors.New("dataset not found")
+			}
+			if editionID == "edition-not-found" {
+				return datasetAPIModels.Version{}, errors.New("edition not found")
+			}
+			if versionID == "404" {
 				return datasetAPIModels.Version{}, errors.New("version not found")
 			}
 			return datasetAPIModels.Version{}, nil

--- a/models/content.go
+++ b/models/content.go
@@ -85,52 +85,47 @@ func CleanContentItem(contentItem *ContentItem) {
 
 func ValidateContentItem(contentItem *ContentItem) []*Error {
 	var (
-		missingFields = []*Error{}
-		invalidFields = []*Error{}
+		invalidOrMissingFields = []*Error{}
 	)
 
 	codeMissingParameters := CodeMissingParameters
 	codeInvalidParameters := CodeInvalidParameters
 
 	if contentItem.BundleID == "" {
-		missingFields = append(missingFields, &Error{Code: &codeMissingParameters, Description: errs.ErrorDescriptionMalformedRequest, Source: &Source{Field: "/bundle_id"}})
+		invalidOrMissingFields = append(invalidOrMissingFields, &Error{Code: &codeMissingParameters, Description: errs.ErrorDescriptionMissingParameters, Source: &Source{Field: "/bundle_id"}})
 	}
 
 	if contentItem.ContentType == "" {
-		missingFields = append(missingFields, &Error{Code: &codeMissingParameters, Description: errs.ErrorDescriptionMalformedRequest, Source: &Source{Field: "/content_type"}})
+		invalidOrMissingFields = append(invalidOrMissingFields, &Error{Code: &codeMissingParameters, Description: errs.ErrorDescriptionMissingParameters, Source: &Source{Field: "/content_type"}})
 	}
 
-	if !contentItem.ContentType.IsValid() {
-		invalidFields = append(invalidFields, &Error{Code: &codeInvalidParameters, Description: errs.ErrorDescriptionMalformedRequest, Source: &Source{Field: "/content_type"}})
+	if contentItem.ContentType != "" && !contentItem.ContentType.IsValid() {
+		invalidOrMissingFields = append(invalidOrMissingFields, &Error{Code: &codeInvalidParameters, Description: errs.ErrorDescriptionMalformedRequest, Source: &Source{Field: "/content_type"}})
 	}
 
 	if contentItem.Metadata.DatasetID == "" {
-		missingFields = append(missingFields, &Error{Code: &codeMissingParameters, Description: errs.ErrorDescriptionMalformedRequest, Source: &Source{Field: "/metadata/dataset_id"}})
+		invalidOrMissingFields = append(invalidOrMissingFields, &Error{Code: &codeMissingParameters, Description: errs.ErrorDescriptionMissingParameters, Source: &Source{Field: "/metadata/dataset_id"}})
 	}
 	if contentItem.Metadata.EditionID == "" {
-		missingFields = append(missingFields, &Error{Code: &codeMissingParameters, Description: errs.ErrorDescriptionMalformedRequest, Source: &Source{Field: "/metadata/edition_id"}})
+		invalidOrMissingFields = append(invalidOrMissingFields, &Error{Code: &codeMissingParameters, Description: errs.ErrorDescriptionMissingParameters, Source: &Source{Field: "/metadata/edition_id"}})
 	}
 	if contentItem.Metadata.VersionID < 1 {
-		invalidFields = append(invalidFields, &Error{Code: &codeInvalidParameters, Description: errs.ErrorDescriptionMalformedRequest, Source: &Source{Field: "/metadata/version_id"}})
+		invalidOrMissingFields = append(invalidOrMissingFields, &Error{Code: &codeInvalidParameters, Description: errs.ErrorDescriptionMalformedRequest, Source: &Source{Field: "/metadata/version_id"}})
 	}
 
 	if contentItem.State != nil && !contentItem.State.IsValid() {
-		invalidFields = append(invalidFields, &Error{Code: &codeInvalidParameters, Description: errs.ErrorDescriptionMalformedRequest, Source: &Source{Field: "/state"}})
+		invalidOrMissingFields = append(invalidOrMissingFields, &Error{Code: &codeInvalidParameters, Description: errs.ErrorDescriptionMalformedRequest, Source: &Source{Field: "/state"}})
 	}
 
 	if contentItem.Links.Edit == "" {
-		missingFields = append(missingFields, &Error{Code: &codeMissingParameters, Description: errs.ErrorDescriptionMalformedRequest, Source: &Source{Field: "/links/edit"}})
+		invalidOrMissingFields = append(invalidOrMissingFields, &Error{Code: &codeMissingParameters, Description: errs.ErrorDescriptionMissingParameters, Source: &Source{Field: "/links/edit"}})
 	}
 	if contentItem.Links.Preview == "" {
-		missingFields = append(missingFields, &Error{Code: &codeMissingParameters, Description: errs.ErrorDescriptionMalformedRequest, Source: &Source{Field: "/links/preview"}})
+		invalidOrMissingFields = append(invalidOrMissingFields, &Error{Code: &codeMissingParameters, Description: errs.ErrorDescriptionMissingParameters, Source: &Source{Field: "/links/preview"}})
 	}
 
-	if len(missingFields) > 0 {
-		return missingFields
-	}
-
-	if len(invalidFields) > 0 {
-		return invalidFields
+	if len(invalidOrMissingFields) > 0 {
+		return invalidOrMissingFields
 	}
 
 	return nil

--- a/models/content_test.go
+++ b/models/content_test.go
@@ -214,38 +214,95 @@ func TestValidateContentItem_Success(t *testing.T) {
 }
 
 func TestValidateContentItem_Failure(t *testing.T) {
-	Convey("Given a ContentItem with missing mandatory fields", t, func() {
-		contentItem := ContentItem{}
+	Convey("Given a ContentItem with all fields missing/invalid", t, func() {
+		contentItem := ContentItem{State: &contentItemStateInvalid}
 
-		Convey("When ValidateContentItem is called", func() {
-			err := ValidateContentItem(&contentItem)
+		Convey("When ValidateContentItem is called (content_type missing)", func() {
+			validationErrs := ValidateContentItem(&contentItem)
 
-			Convey("Then it should return an error indicating the missing fields", func() {
-				So(err, ShouldNotBeNil)
-				So(err[0].Source.Field, ShouldEqual, "/bundle_id")
-				So(err[1].Source.Field, ShouldEqual, "/content_type")
-				So(err[2].Source.Field, ShouldEqual, "/metadata/dataset_id")
-				So(err[3].Source.Field, ShouldEqual, "/metadata/edition_id")
-				So(err[4].Source.Field, ShouldEqual, "/links/edit")
-				So(err[5].Source.Field, ShouldEqual, "/links/preview")
+			Convey("Then it should return validation errors for all missing/invalid fields", func() {
+				So(validationErrs, ShouldNotBeEmpty)
+				So(len(validationErrs), ShouldBeGreaterThan, 0)
+
+				codeMissingParameters := CodeMissingParameters
+				codeInvalidParameters := CodeInvalidParameters
+
+				So(validationErrs[0].Source.Field, ShouldEqual, "/bundle_id")
+				So(validationErrs[0].Description, ShouldEqual, errs.ErrorDescriptionMissingParameters)
+				So(validationErrs[0].Code, ShouldEqual, &codeMissingParameters)
+
+				So(validationErrs[1].Source.Field, ShouldEqual, "/content_type")
+				So(validationErrs[1].Description, ShouldEqual, errs.ErrorDescriptionMissingParameters)
+				So(validationErrs[1].Code, ShouldEqual, &codeMissingParameters)
+
+				So(validationErrs[2].Source.Field, ShouldEqual, "/metadata/dataset_id")
+				So(validationErrs[2].Description, ShouldEqual, errs.ErrorDescriptionMissingParameters)
+				So(validationErrs[2].Code, ShouldEqual, &codeMissingParameters)
+
+				So(validationErrs[3].Source.Field, ShouldEqual, "/metadata/edition_id")
+				So(validationErrs[3].Description, ShouldEqual, errs.ErrorDescriptionMissingParameters)
+				So(validationErrs[3].Code, ShouldEqual, &codeMissingParameters)
+
+				So(validationErrs[4].Source.Field, ShouldEqual, "/metadata/version_id")
+				So(validationErrs[4].Description, ShouldEqual, errs.ErrorDescriptionMalformedRequest)
+				So(validationErrs[4].Code, ShouldEqual, &codeInvalidParameters)
+
+				So(validationErrs[5].Source.Field, ShouldEqual, "/state")
+				So(validationErrs[5].Description, ShouldEqual, errs.ErrorDescriptionMalformedRequest)
+				So(validationErrs[5].Code, ShouldEqual, &codeInvalidParameters)
+
+				So(validationErrs[6].Source.Field, ShouldEqual, "/links/edit")
+				So(validationErrs[6].Description, ShouldEqual, errs.ErrorDescriptionMissingParameters)
+				So(validationErrs[6].Code, ShouldEqual, &codeMissingParameters)
+
+				So(validationErrs[7].Source.Field, ShouldEqual, "/links/preview")
+				So(validationErrs[7].Description, ShouldEqual, errs.ErrorDescriptionMissingParameters)
+				So(validationErrs[7].Code, ShouldEqual, &codeMissingParameters)
 			})
 		})
-	})
 
-	Convey("Given a ContentItem with invalid fields", t, func() {
-		contentItem := fullyPopulatedContentItem
-		contentItem.ContentType = "invalid_content_type"
-		contentItem.Metadata.VersionID = -1
-		contentItem.State = &contentItemStateInvalid
+		Convey("When ValidateContentItem is called (content_type invalid)", func() {
+			contentItem.ContentType = ContentType("InvalidContentType")
+			validationErrs := ValidateContentItem(&contentItem)
 
-		Convey("When ValidateContentItem is called", func() {
-			err := ValidateContentItem(&contentItem)
+			Convey("Then it should return validation errors for all missing/invalid fields", func() {
+				So(validationErrs, ShouldNotBeEmpty)
+				So(len(validationErrs), ShouldBeGreaterThan, 0)
 
-			Convey("Then it should return an error indicating the invalid fields", func() {
-				So(err, ShouldNotBeNil)
-				So(err[0].Source.Field, ShouldEqual, "/content_type")
-				So(err[1].Source.Field, ShouldEqual, "/metadata/version_id")
-				So(err[2].Source.Field, ShouldEqual, "/state")
+				codeMissingParameters := CodeMissingParameters
+				codeInvalidParameters := CodeInvalidParameters
+
+				So(validationErrs[0].Source.Field, ShouldEqual, "/bundle_id")
+				So(validationErrs[0].Description, ShouldEqual, errs.ErrorDescriptionMissingParameters)
+				So(validationErrs[0].Code, ShouldEqual, &codeMissingParameters)
+
+				So(validationErrs[1].Source.Field, ShouldEqual, "/content_type")
+				So(validationErrs[1].Description, ShouldEqual, errs.ErrorDescriptionMalformedRequest)
+				So(validationErrs[1].Code, ShouldEqual, &codeInvalidParameters)
+
+				So(validationErrs[2].Source.Field, ShouldEqual, "/metadata/dataset_id")
+				So(validationErrs[2].Description, ShouldEqual, errs.ErrorDescriptionMissingParameters)
+				So(validationErrs[2].Code, ShouldEqual, &codeMissingParameters)
+
+				So(validationErrs[3].Source.Field, ShouldEqual, "/metadata/edition_id")
+				So(validationErrs[3].Description, ShouldEqual, errs.ErrorDescriptionMissingParameters)
+				So(validationErrs[3].Code, ShouldEqual, &codeMissingParameters)
+
+				So(validationErrs[4].Source.Field, ShouldEqual, "/metadata/version_id")
+				So(validationErrs[4].Description, ShouldEqual, errs.ErrorDescriptionMalformedRequest)
+				So(validationErrs[4].Code, ShouldEqual, &codeInvalidParameters)
+
+				So(validationErrs[5].Source.Field, ShouldEqual, "/state")
+				So(validationErrs[5].Description, ShouldEqual, errs.ErrorDescriptionMalformedRequest)
+				So(validationErrs[5].Code, ShouldEqual, &codeInvalidParameters)
+
+				So(validationErrs[6].Source.Field, ShouldEqual, "/links/edit")
+				So(validationErrs[6].Description, ShouldEqual, errs.ErrorDescriptionMissingParameters)
+				So(validationErrs[6].Code, ShouldEqual, &codeMissingParameters)
+
+				So(validationErrs[7].Source.Field, ShouldEqual, "/links/preview")
+				So(validationErrs[7].Description, ShouldEqual, errs.ErrorDescriptionMissingParameters)
+				So(validationErrs[7].Code, ShouldEqual, &codeMissingParameters)
 			})
 		})
 	})

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -344,6 +344,8 @@ paths:
           $ref: "#/responses/NotFound"
         403:
           $ref: "#/responses/ForbiddenError"
+        409:
+          $ref: "#/responses/Conflict"
         500:
           $ref: "#/responses/InternalError"
   /bundles/{id}/contents/{content_id}:


### PR DESCRIPTION
### What

- When validating a content item, invalid and missing fields have separate codes and descriptions. They will also all be returned in the same list
- When calling `getVersion` from the dataset-api, we now specify if the dataset, edition or version caused the error
- 409 possible response added to swagger spec for when content item already exists
- Unit and component test coverage improved

### How to review

Check changes are ok and CI passes

Locally testing:
- Run the `dataset-catalogue` stack using `make-up-with-seed`
- Use access-token as `Authorization` header and set `KL9384TY-721M-175N-6P7J-23BC5841G132` as `X-Florence-Token` header
- body for request (working):
```
{
    "content_type" : "DATASET",
    "metadata" : {
        "dataset_id" : "static-test-dataset",
        "edition_id" : "time-series",
        "version_id" : 1,
        "title" : "Dataset 0"
    },
    "links" : {
        "edit" : "edit/link",
        "preview" : "preview/link"
    }
}
```
- Try with incorrect version then edition then dataset IDs to see if error specifies field
- Try removing links and making content_type invalid to see if all errors show in a list

### Who can review

Anyone
