### PR TITLE
feat: add utils for common request + response methods

### DIFF
--- a/apierrors/errors.go
+++ b/apierrors/errors.go
@@ -1,6 +1,9 @@
 package apierrors
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
 
 // Custom error types for common HTTP cases
 type ErrInvalidPatch struct {
@@ -12,19 +15,45 @@ func (e ErrInvalidPatch) Error() string {
 }
 
 // Response error descriptions
-var (
+const (
 	ErrorDescriptionMalformedRequest  = "Unable to process request due to a malformed or invalid request body or query parameter"
 	ErrorDescriptionMissingParameters = "Unable to process request due to missing required parameters in the request body or query parameters"
 	ErrorDescriptionNotFound          = "The requested resource does not exist"
 	ErrorDescriptionInternalError     = "Failed to process the request due to an internal error"
+
+	// Requests
+	ErrorDescriptionNoParametersFound = "No URL parameters found"
+	ErrorDescriptionETagMissing       = "ETag header is required"
+	ErrorDescriptionETagMismatch      = "Supplied ETag does not match"
+
+	// Bundle specific errors
+	ErrorDescriptionNoContentItemsFound = "No content items found"
+	ErrorDescriptionMissingBundleID     = "missing bundle ID"
+	ErrorDescriptionEmptyBundleID       = "Bundle ID cannot be empty"
+
+	// Identity
+	ErrorDescriptionUserIdentityParseFailed = "Failed to get user identity from JWT"
+
+	// Validation
+	ErrorDescriptionValidationEventFailed = "Failed to validate event"
 )
+
+// CreateMissingRouteVariableError creates a standard error message string for if a route variable is missing
+func CreateMissingRouteVariableError(variable string) string {
+	return fmt.Sprintf("Missing %s", variable)
+}
+
+// CreateMissingRouteVariableError creates a standard error message string for if a route variable is provided but empty
+func CreateEmptyRouteVariableError(variable string) string {
+	return fmt.Sprintf("%s cannot be empty", variable)
+}
 
 var (
 	ErrUnableToReadMessage = errors.New("failed to read message body")
 	ErrUnableToParseJSON   = errors.New("failed to parse json body")
 )
 
-var (
+const (
 	ErrUnmarshalJSONObject    = "Failed to unmarshal bundle resource into bytes"
 	ErrMarshalJSONObject      = "Failed to Marshal bundle resource into bytes"
 	ErrWritingBytesToResponse = "Failed writing bytes to response"
@@ -43,7 +72,7 @@ var (
 	ErrDeleteBundleForbidden  = errors.New("cannot delete a published bundle")
 	ErrBundleAlreadyExists    = errors.New("bundle already exists")
 	ErrInvalidBundleState     = errors.New("invalid bundle state")
-	ErrMissingBundleID        = errors.New("missing bundle ID")
+	ErrMissingBundleID        = errors.New(ErrorDescriptionMissingBundleID)
 	ErrInvalidBundleReference = errors.New("invalid bundle reference")
 	ErrBundleEventNotFound    = errors.New("bundle event not found")
 
@@ -51,6 +80,7 @@ var (
 	ErrMissingParameters      = errors.New("missing required parameters in request")
 	ErrInvalidQueryParameter  = errors.New("invalid query parameter")
 	ErrTooManyQueryParameters = errors.New("too many query parameters provided")
+	ErrMismatchedETag         = errors.New("etag does not match")
 
 	// State errors
 	ErrExpectedStateOfCreated  = errors.New("expected bundle state to be 'CREATED'")

--- a/models/api.go
+++ b/models/api.go
@@ -1,0 +1,14 @@
+package models
+
+const (
+	RouteBundleID = "bundle-id"
+)
+
+const (
+	KeyBundleID         = "bundle_id"
+	KeyBundleState      = "bundle_state"
+	KeyContentItemID    = "content_id"
+	KeyContentItemState = "content_item_state"
+	KeyCurrentState     = "current_state"
+	KeyTargetState      = "target_state"
+)

--- a/models/bundle_requests.go
+++ b/models/bundle_requests.go
@@ -1,0 +1,5 @@
+package models
+
+type UpdateBundleStateRequest struct {
+	State BundleState
+}

--- a/models/content.go
+++ b/models/content.go
@@ -2,7 +2,9 @@ package models
 
 import (
 	"encoding/json"
+	"errors"
 	"io"
+	"strconv"
 	"strings"
 
 	errs "github.com/ONSdigital/dis-bundle-api/apierrors"
@@ -131,6 +133,10 @@ func ValidateContentItem(contentItem *ContentItem) []*Error {
 	return nil
 }
 
+func (ci *ContentItem) VersionIDString() string {
+	return strconv.Itoa(ci.Metadata.VersionID)
+}
+
 // ContentType enum represents the type of content
 type ContentType string
 
@@ -161,6 +167,8 @@ type State string
 const (
 	StateApproved  State = "APPROVED"
 	StatePublished State = "PUBLISHED"
+	StateDraft     State = "DRAFT"
+	StateInReview  State = "IN_REVIEW"
 )
 
 // IsValid validates that the State is a valid enum value
@@ -176,4 +184,25 @@ func (s State) IsValid() bool {
 // String returns the string value of the State
 func (s State) String() string {
 	return string(s)
+}
+
+func GetMatchingStateForBundleState(bundleState BundleState) (*State, error) {
+	str := bundleState.String()
+	var state State
+	switch str {
+	case StateApproved.String():
+		state = StateApproved
+		return &state, nil
+	case StatePublished.String():
+		state = StatePublished
+		return &state, nil
+	case StateDraft.String():
+		state = StateDraft
+		return &state, nil
+	case StateInReview.String():
+		state = StateInReview
+		return &state, nil
+	default:
+		return nil, errors.New("not found state")
+	}
 }

--- a/models/error.go
+++ b/models/error.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 
 	errs "github.com/ONSdigital/dis-bundle-api/apierrors"
 )
@@ -41,6 +42,14 @@ func CreateError(reader io.Reader) (*Error, error) {
 	}
 
 	return &errorObj, nil
+}
+
+// Create instance of models.Error
+func CreateModelError(code Code, description string) *Error {
+	return &Error{
+		Code:        &code,
+		Description: description,
+	}
 }
 
 func ValidateError(e *Error) error {
@@ -106,4 +115,25 @@ func (c Code) IsValid() bool {
 // String returns the string value of the Code
 func (c Code) String() string {
 	return string(c)
+}
+
+func (c Code) HTTPStatusCode() int {
+	switch c {
+	case CodeInternalServerError, InternalError:
+		return http.StatusInternalServerError
+	case CodeNotFound, NotFound:
+		return http.StatusNotFound
+	case CodeUnauthorized, Unauthorised:
+		return http.StatusUnauthorized
+	case CodeInvalidParameters, ErrInvalidParameters, CodeMissingParameters:
+		return http.StatusBadRequest
+	case CodeForbidden:
+		return http.StatusForbidden
+	case CodeConflict:
+		return http.StatusConflict
+	case CodeBadRequest:
+		return http.StatusBadRequest
+	default:
+		return http.StatusInternalServerError
+	}
 }

--- a/models/event.go
+++ b/models/event.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"time"
@@ -32,6 +33,26 @@ type EventBundle struct {
 	Title         string         `bson:"title"                     json:"title"`
 	UpdatedAt     *time.Time     `bson:"updated_at,omitempty"      json:"updated_at,omitempty"`
 	ManagedBy     ManagedBy      `bson:"managed_by"                json:"managed_by"`
+}
+
+func CreateEventBundle(bundle *Bundle) (*EventBundle, error) {
+	if bundle == nil {
+		return nil, errors.New("bundle is nil")
+	}
+
+	return &EventBundle{
+		ID:            bundle.ID,
+		BundleType:    bundle.BundleType,
+		CreatedBy:     bundle.CreatedBy,
+		CreatedAt:     bundle.CreatedAt,
+		LastUpdatedBy: bundle.LastUpdatedBy,
+		PreviewTeams:  bundle.PreviewTeams,
+		ScheduledAt:   bundle.ScheduledAt,
+		State:         bundle.State,
+		Title:         bundle.Title,
+		UpdatedAt:     bundle.UpdatedAt,
+		ManagedBy:     bundle.ManagedBy,
+	}, nil
 }
 
 // RequestedBy represents the user who made the request

--- a/utils/headers.go
+++ b/utils/headers.go
@@ -1,0 +1,23 @@
+package utils
+
+// Header key constants
+const (
+	HeaderAuthorization = "Authorization"
+	HeaderCacheControl  = "Cache-Control"
+	HeaderLocation      = "Location"
+	HeaderContentType   = "Content-Type"
+	HeaderETag          = "ETag"
+	HeaderFlorenceToken = "X-Florence-Token"
+	HeaderIfMatch       = "If-Match"
+)
+
+// CacheControl represents a value for the Cache-Control header
+type CacheControl string
+
+const (
+	CacheControlNoStore CacheControl = "no-store"
+)
+
+func (c CacheControl) String() string {
+	return string(c)
+}

--- a/utils/requests.go
+++ b/utils/requests.go
@@ -1,0 +1,65 @@
+package utils
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+
+	"github.com/ONSdigital/dis-bundle-api/apierrors"
+	"github.com/ONSdigital/dis-bundle-api/models"
+	"github.com/gorilla/mux"
+)
+
+// GetBundleID gets the Bundle ID from route vars from the provided request
+func GetBundleID(r *http.Request) (string, *models.Error) {
+	return GetRouteVariableWithDefaultErrors(r, models.RouteBundleID)
+}
+
+// GetRouteVariableWithDefaultErrors gets the specified route variable from the provided request, and returns default error messages constructed using the variable's name
+func GetRouteVariableWithDefaultErrors(r *http.Request, variable string) (string, *models.Error) {
+	return GetRouteVariable(r, variable, apierrors.CreateMissingRouteVariableError(variable), apierrors.CreateMissingRouteVariableError(variable))
+}
+
+// GetRouteVariable gets the specified route variable from the provided request, and returns the provided errors if the variable is missing or empty.
+func GetRouteVariable(r *http.Request, variable, missingError, emptyError string) (string, *models.Error) {
+	vars := mux.Vars(r)
+	if len(vars) == 0 {
+		return "", models.CreateModelError(models.CodeBadRequest, apierrors.ErrorDescriptionMissingParameters)
+	}
+
+	variable, ok := vars[variable]
+	if !ok {
+		return "", models.CreateModelError(models.CodeBadRequest, missingError)
+	}
+
+	if variable == "" {
+		return "", models.CreateModelError(models.CodeBadRequest, emptyError)
+	}
+
+	return variable, nil
+}
+
+// GetETag gets the ETag value from the If-Match header in the provided http.Request object
+func GetETag(r *http.Request) (*string, *models.Error) {
+	etag := r.Header.Get(HeaderIfMatch)
+	if etag == "" {
+		return nil, models.CreateModelError(models.CodeBadRequest, apierrors.ErrorDescriptionETagMissing)
+	}
+
+	return &etag, nil
+}
+
+// GetJSONRequestBody reads the body from the http.Request and tries to unmarshal it as a JSON to the specified type T
+func GetJSONRequestBody[T any](r *http.Request) (*T, *models.Error) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return nil, models.CreateModelError(models.CodeBadRequest, apierrors.ErrorDescriptionMalformedRequest)
+	}
+	var requestBody T
+	err = json.Unmarshal(body, &requestBody)
+	if err != nil {
+		return nil, models.CreateModelError(models.CodeBadRequest, apierrors.ErrorDescriptionMalformedRequest)
+	}
+
+	return &requestBody, nil
+}

--- a/utils/requests_test.go
+++ b/utils/requests_test.go
@@ -1,0 +1,208 @@
+package utils
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/ONSdigital/dis-bundle-api/apierrors"
+	"github.com/ONSdigital/dis-bundle-api/models"
+	"github.com/gorilla/mux"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func createRouteVariableTestRequest(key, value string) *http.Request {
+	r, _ := http.NewRequest("GET", "/", http.NoBody)
+	vars := map[string]string{}
+
+	if key != "" {
+		vars[key] = value
+	}
+
+	r = mux.SetURLVars(r, vars)
+	return r
+}
+
+func TestGetRouteVariable(t *testing.T) {
+	const (
+		ExpectedKey   = "testing-key"
+		ExpectedValue = "testing-value"
+		MissingError  = "testing missing error"
+		EmptyError    = "testing empty error"
+	)
+
+	Convey("When the route variable exists and is not empty", t, func() {
+		r := createRouteVariableTestRequest(ExpectedKey, ExpectedValue)
+
+		Convey("Then it should return the expected value", func() {
+			value, err := GetRouteVariable(r, ExpectedKey, MissingError, EmptyError)
+
+			So(err, ShouldBeNil)
+			So(value, ShouldEqual, ExpectedValue)
+		})
+	})
+
+	Convey("When the no route variables expst", t, func() {
+		r := createRouteVariableTestRequest("", "")
+
+		Convey("Then it should return the missing params error", func() {
+			value, err := GetRouteVariable(r, ExpectedKey, MissingError, EmptyError)
+
+			So(value, ShouldEqual, "")
+
+			So(err, ShouldNotBeNil)
+			So(*err.Code, ShouldEqual, models.CodeBadRequest)
+			So(err.Description, ShouldEqual, apierrors.ErrorDescriptionMissingParameters)
+		})
+	})
+
+	Convey("When the route variable is missing", t, func() {
+		r := createRouteVariableTestRequest("some-other-key", "")
+
+		Convey("Then it should return the missing error", func() {
+			value, err := GetRouteVariable(r, ExpectedKey, MissingError, EmptyError)
+
+			So(value, ShouldEqual, "")
+
+			So(err, ShouldNotBeNil)
+			So(*err.Code, ShouldEqual, models.CodeBadRequest)
+			So(err.Description, ShouldEqual, MissingError)
+		})
+	})
+
+	Convey("When the route variable is empty", t, func() {
+		r := createRouteVariableTestRequest(ExpectedKey, "")
+
+		Convey("Then it should return the empty error", func() {
+			value, err := GetRouteVariable(r, ExpectedKey, MissingError, EmptyError)
+
+			So(value, ShouldEqual, "")
+
+			So(err, ShouldNotBeNil)
+			So(*err.Code, ShouldEqual, models.CodeBadRequest)
+			So(err.Description, ShouldEqual, EmptyError)
+		})
+	})
+}
+
+func createGetETagTestRequest(value *string) *http.Request {
+	r, _ := http.NewRequest("GET", "/", http.NoBody)
+
+	if value != nil {
+		r.Header.Set(HeaderIfMatch, *value)
+	}
+	return r
+}
+
+func TestGetETag(t *testing.T) {
+	Convey("When the etag header is set", t, func() {
+		value := "test-etag"
+		r := createGetETagTestRequest(&value)
+
+		Convey("Then it should be returned with no error", func() {
+			etag, err := GetETag(r)
+
+			So(err, ShouldBeNil)
+			So(etag, ShouldEqual, &value)
+		})
+	})
+
+	Convey("When the etag header is not set", t, func() {
+		r := createGetETagTestRequest(nil)
+
+		Convey("Then it should be returned with no error", func() {
+			etag, err := GetETag(r)
+
+			So(etag, ShouldBeNil)
+
+			So(err, ShouldNotBeNil)
+			So(*err.Code, ShouldEqual, models.CodeBadRequest)
+			So(err.Description, ShouldEqual, apierrors.ErrorDescriptionETagMissing)
+		})
+	})
+}
+
+type TestRequestBody struct {
+	BundleID string `json:"bundle_id"`
+	Version  int    `json:"version"`
+}
+
+func createGetRequestBodyTestRequest(body []byte) *http.Request {
+	var bodyReader *bytes.Reader
+	if body != nil {
+		bodyReader = bytes.NewReader(body)
+	} else {
+		bodyReader = bytes.NewReader([]byte{})
+	}
+
+	r, _ := http.NewRequest("POST", "/test", bodyReader)
+	return r
+}
+
+func createValidJSON(bundleID string, version int) []byte {
+	jsonString := fmt.Sprintf(`{"bundle_id":%q,"version":%d}`, bundleID, version)
+
+	return []byte(jsonString)
+}
+
+func TestGetRequestBody(t *testing.T) {
+	const (
+		BundleID = "bundle-1234"
+		Version  = 1
+	)
+	Convey("When the request body contains valid JSON", t, func() {
+		validJSON := createValidJSON(BundleID, Version)
+		r := createGetRequestBodyTestRequest(validJSON)
+
+		Convey("Then it should parse successfully and return the struct", func() {
+			result, err := GetJSONRequestBody[TestRequestBody](r)
+
+			So(err, ShouldBeNil)
+			So(result, ShouldNotBeNil)
+			So(result.BundleID, ShouldEqual, BundleID)
+			So(result.Version, ShouldEqual, Version)
+		})
+	})
+
+	Convey("When the request body is empty", t, func() {
+		r := createGetRequestBodyTestRequest([]byte{})
+
+		Convey("Then it should return an error", func() {
+			result, err := GetJSONRequestBody[TestRequestBody](r)
+
+			So(result, ShouldBeNil)
+			So(err, ShouldNotBeNil)
+			So(*err.Code, ShouldEqual, models.CodeBadRequest)
+			So(err.Description, ShouldEqual, apierrors.ErrorDescriptionMalformedRequest)
+		})
+	})
+
+	Convey("When the request body contains invalid JSON", t, func() {
+		invalidJSON := []byte(`{"bundle_id":"bundle","version":}`)
+		r := createGetRequestBodyTestRequest(invalidJSON)
+
+		Convey("Then it should return an error", func() {
+			result, err := GetJSONRequestBody[TestRequestBody](r)
+
+			So(result, ShouldBeNil)
+			So(err, ShouldNotBeNil)
+			So(*err.Code, ShouldEqual, models.CodeBadRequest)
+			So(err.Description, ShouldEqual, apierrors.ErrorDescriptionMalformedRequest)
+		})
+	})
+
+	Convey("When the request body contains malformed JSON", t, func() {
+		malformedJSON := []byte(`{this is not valid json}`)
+		r := createGetRequestBodyTestRequest(malformedJSON)
+
+		Convey("Then it should return an error", func() {
+			result, err := GetJSONRequestBody[TestRequestBody](r)
+
+			So(result, ShouldBeNil)
+			So(err, ShouldNotBeNil)
+			So(*err.Code, ShouldEqual, models.CodeBadRequest)
+			So(err.Description, ShouldEqual, apierrors.ErrorDescriptionMalformedRequest)
+		})
+	})
+}

--- a/utils/response_builder.go
+++ b/utils/response_builder.go
@@ -1,0 +1,177 @@
+package utils
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	dpresponse "github.com/ONSdigital/dp-net/v3/handlers/response"
+)
+
+// HTTPResponseBuilder provides a fluent interface for building HTTP responses.
+// It allows chaining method calls to configure headers, body, ETag, cache control,
+// and status code before writing the response.
+type HTTPResponseBuilder interface {
+	// WithHeader adds a custom header to the HTTP response
+	WithHeader(key string, value string) HTTPResponseBuilder
+
+	// WithETag sets the ETag header for the HTTP response.
+	WithETag(value string) HTTPResponseBuilder
+
+	// WithCacheControl sets the Cache-Control header for the HTTP response.
+	WithCacheControl(value CacheControl) HTTPResponseBuilder
+
+	// WithJSONBody sets the response body as JSON content.
+	WithJSONBody(body any) HTTPResponseBuilder
+
+	// WithBody sets the response body with a specific content type.
+	WithBody(bodyType ContentType, body any) HTTPResponseBuilder
+
+	// WithStatusCode sets the status code of the HTTP response
+	WithStatusCode(statusCode int) HTTPResponseBuilder
+
+	// Build constructs and writes the HTTP response with the values that were set in the various With... methods
+	Build(responseWriter http.ResponseWriter) error
+}
+
+type ResponseWriter interface {
+	Write(responseWriter http.ResponseWriter) error
+}
+
+// Concrete implementation of HTTPResponseBuilder
+type ResponseBuilder struct {
+	headers    map[string]string // HTTP headers to write in the response
+	etag       *string           // ETag value to write in the response headers
+	body       *ResponseBody     // Response body to write
+	statusCode int               // Response status code
+}
+
+// Interface checks
+var _ HTTPResponseBuilder = (*ResponseBuilder)(nil)
+var _ ResponseWriter = (*ResponseBody)(nil)
+
+// ContentType is the content type of the response body to write
+type ContentType string
+
+const (
+	ContentTypeJSON ContentType = "application/json"
+)
+
+// ResponseBody encapsulates the response body content and its content type
+type ResponseBody struct {
+	responseType ContentType
+	body         interface{}
+}
+
+func createResponseBody(responseType ContentType, body any) *ResponseBody {
+	return &ResponseBody{
+		responseType: responseType,
+		body:         body,
+	}
+}
+
+func CreateHTTPResponseBuilder() HTTPResponseBuilder {
+	return &ResponseBuilder{
+		headers: make(map[string]string),
+	}
+}
+
+// WithHeader adds a custom header for writing to the HTTP response
+func (r *ResponseBuilder) WithHeader(key, value string) HTTPResponseBuilder {
+	r.headers[key] = value
+	return r
+}
+
+// WithETag sets the ETag header for writing to the HTTP response
+func (r *ResponseBuilder) WithETag(value string) HTTPResponseBuilder {
+	r.etag = &value
+	return r
+}
+
+// WithCacheControl sets the Cache-Control header for writing to the HTTP response
+func (r *ResponseBuilder) WithCacheControl(value CacheControl) HTTPResponseBuilder {
+	r.headers[HeaderCacheControl] = value.String()
+	return r
+}
+
+// WithJSONBody sets the body for the HTTP response, to be marshalled as a JSON response
+func (r *ResponseBuilder) WithJSONBody(body any) HTTPResponseBuilder {
+	return r.WithBody(ContentTypeJSON, body)
+}
+
+// WithBody sets the body for the HTTP response, with the specified body content type
+func (r *ResponseBuilder) WithBody(contentType ContentType, body any) HTTPResponseBuilder {
+	r.body = createResponseBody(contentType, body)
+
+	return r
+}
+
+// WithStatusCode sets the HTTP status code for the response
+func (r *ResponseBuilder) WithStatusCode(statusCode int) HTTPResponseBuilder {
+	r.statusCode = statusCode
+	return r
+}
+
+// Build constructs and writes the HTTP response to the provided ResponseWriter.
+func (r *ResponseBuilder) Build(responseWriter http.ResponseWriter) error {
+	if r.etag != nil {
+		dpresponse.SetETag(responseWriter, *r.etag)
+	}
+
+	for key, value := range r.headers {
+		responseWriter.Header().Set(key, value)
+	}
+
+	if r.statusCode > 0 {
+		responseWriter.WriteHeader(r.statusCode)
+	}
+
+	if r.body != nil {
+		err := r.body.Write(responseWriter)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Write writes the ResponseBody's body to the ResponseWriter
+func (rb *ResponseBody) Write(r http.ResponseWriter) error {
+	var body *[]byte
+	var err error
+
+	r.Header().Set(HeaderContentType, string(rb.responseType))
+
+	switch rb.responseType {
+	case ContentTypeJSON:
+		body, err = rb.marshalJSONBody()
+	default:
+		err = fmt.Errorf("response body type %s is not implemented", rb.responseType)
+	}
+
+	if err != nil {
+		return err
+	}
+
+	if _, err := r.Write(*body); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// marshalJSONBody marshals the ResponseBody's body object to a *[]byte
+func (rb *ResponseBody) marshalJSONBody() (*[]byte, error) {
+	if rb.body == nil {
+		return nil, errors.New("body is nil")
+	}
+
+	body, err := json.Marshal(rb.body)
+	if err != nil {
+		return nil, err
+	}
+
+	return &body, nil
+}

--- a/utils/response_builder_test.go
+++ b/utils/response_builder_test.go
@@ -1,0 +1,272 @@
+package utils
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ONSdigital/dis-bundle-api/models"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestCreateResponseBuilder(t *testing.T) {
+	Convey("CreateResponseBuilder", t, func() {
+		Convey("Should create a response builder", func() {
+			responseBuilder := CreateHTTPResponseBuilder()
+
+			So(responseBuilder, ShouldNotBeNil)
+		})
+	})
+
+	Convey("CreateResponseBuilder", t, func() {
+		Convey("Should create a response builder with default values", func() {
+			httpResponseBuilder := CreateHTTPResponseBuilder()
+
+			So(httpResponseBuilder, ShouldNotBeNil)
+
+			responseBuilder := httpResponseBuilder.(*ResponseBuilder)
+			So(responseBuilder.headers, ShouldNotBeNil)
+			So(responseBuilder.headers, ShouldBeEmpty)
+
+			So(responseBuilder.statusCode, ShouldEqual, 0)
+			So(responseBuilder.body, ShouldBeNil)
+
+			So(responseBuilder.etag, ShouldBeNil)
+		})
+	})
+
+	Convey("WithHeader", t, func() {
+		headerKey := "testing header"
+		headerValue := "test header value"
+		Convey("Should set header", func() {
+			httpResponseBuilder := CreateHTTPResponseBuilder().WithHeader(headerKey, headerValue)
+
+			responseBuilder := httpResponseBuilder.(*ResponseBuilder)
+
+			So(responseBuilder.headers, ShouldNotBeEmpty)
+			So(responseBuilder.headers, ShouldContainKey, headerKey)
+			actualValue := responseBuilder.headers[headerKey]
+			So(actualValue, ShouldEqual, headerValue)
+		})
+	})
+
+	Convey("WithETag", t, func() {
+		etagValue := "etag value"
+		Convey("Should set etag", func() {
+			httpResponseBuilder := CreateHTTPResponseBuilder().WithETag(etagValue)
+			responseBuilder := httpResponseBuilder.(*ResponseBuilder)
+
+			So(responseBuilder.etag, ShouldNotBeNil)
+
+			So(*responseBuilder.etag, ShouldEqual, etagValue)
+		})
+	})
+
+	Convey("WithCacheControl", t, func() {
+		cacheControl := CacheControlNoStore
+
+		Convey("Should set cache control header", func() {
+			httpResponseBuilder := CreateHTTPResponseBuilder().WithCacheControl(cacheControl)
+			responseBuilder := httpResponseBuilder.(*ResponseBuilder)
+
+			So(responseBuilder.headers, ShouldNotBeEmpty)
+			So(responseBuilder.headers, ShouldContainKey, HeaderCacheControl)
+			actualValue := responseBuilder.headers[HeaderCacheControl]
+			So(actualValue, ShouldEqual, cacheControl.String())
+		})
+	})
+
+	Convey("WithStatusCode", t, func() {
+		statusCode := 200
+
+		Convey("Should set status code", func() {
+			httpResponseBuilder := CreateHTTPResponseBuilder().WithStatusCode(statusCode)
+			responseBuilder := httpResponseBuilder.(*ResponseBuilder)
+
+			So(responseBuilder.statusCode, ShouldEqual, statusCode)
+		})
+	})
+
+	Convey("WithBody", t, func() {
+		body := models.Bundle{
+			ID: "bundle-id",
+		}
+
+		responseType := ContentTypeJSON
+
+		Convey("Should set body", func() {
+			httpResponseBuilder := CreateHTTPResponseBuilder().WithBody(ContentTypeJSON, body)
+			responseBuilder := httpResponseBuilder.(*ResponseBuilder)
+
+			So(responseBuilder.body, ShouldNotBeNil)
+			So(responseBuilder.body.responseType, ShouldEqual, responseType)
+			So(responseBuilder.body.body, ShouldEqual, body)
+		})
+	})
+
+	Convey("WithJSONBody", t, func() {
+		body := models.Bundle{
+			ID: "bundle-id",
+		}
+		responseType := ContentTypeJSON
+
+		Convey("Should set body", func() {
+			httpResponseBuilder := CreateHTTPResponseBuilder().WithJSONBody(body)
+			responseBuilder := httpResponseBuilder.(*ResponseBuilder)
+
+			So(responseBuilder.body, ShouldNotBeNil)
+			So(responseBuilder.body.responseType, ShouldEqual, responseType)
+			So(responseBuilder.body.body, ShouldEqual, body)
+		})
+	})
+
+	Convey("Build", t, func() {
+		etagValue := "test-etag-value"
+		cacheControl := CacheControlNoStore
+		headers := map[string]string{
+			"test-header-one":   "test-header-value",
+			"other-test-header": "expected-test-header-value",
+		}
+		statusCode := 400
+		responseBody := models.Bundle{
+			ID:         "bundle-1234",
+			BundleType: models.BundleTypeScheduled,
+		}
+
+		Convey("Should set response etag header", func() {
+			rr := httptest.NewRecorder()
+			CreateHTTPResponseBuilder().WithETag(etagValue).Build(rr)
+
+			So(rr.Header().Get(HeaderETag), ShouldEqual, etagValue)
+		})
+
+		Convey("Should set response cache-control header", func() {
+			rr := httptest.NewRecorder()
+			CreateHTTPResponseBuilder().WithCacheControl(cacheControl).Build(rr)
+
+			So(rr.Header().Get(HeaderCacheControl), ShouldEqual, cacheControl.String())
+		})
+
+		Convey("Should set response headers", func() {
+			rr := httptest.NewRecorder()
+			responseBuilder := CreateHTTPResponseBuilder()
+
+			for key, value := range headers {
+				responseBuilder = responseBuilder.WithHeader(key, value)
+			}
+
+			responseBuilder.Build(rr)
+
+			for key, value := range headers {
+				So(rr.Header().Get(key), ShouldEqual, value)
+			}
+		})
+
+		Convey("Should set status code", func() {
+			rr := httptest.NewRecorder()
+			CreateHTTPResponseBuilder().WithStatusCode(statusCode).Build(rr)
+			So(rr.Result().StatusCode, ShouldEqual, statusCode)
+		})
+
+		Convey("Should set response body + content-type header", func() {
+			rr := httptest.NewRecorder()
+			CreateHTTPResponseBuilder().WithJSONBody(responseBody).Build(rr)
+
+			var responseBundle models.Bundle
+			err := json.NewDecoder(rr.Body).Decode(&responseBundle)
+			So(err, ShouldBeNil)
+			So(responseBundle, ShouldEqual, responseBody)
+		})
+
+		Convey("Should set all", func() {
+			rr := httptest.NewRecorder()
+			builder := CreateHTTPResponseBuilder().
+				WithCacheControl(cacheControl).
+				WithStatusCode(statusCode).
+				WithETag(etagValue).
+				WithJSONBody(responseBody)
+
+			for key, value := range headers {
+				builder = builder.WithHeader(key, value)
+			}
+
+			builder.Build(rr)
+
+			for key, value := range headers {
+				So(rr.Header().Get(key), ShouldEqual, value)
+			}
+
+			var responseBundle models.Bundle
+			err := json.NewDecoder(rr.Body).Decode(&responseBundle)
+			So(err, ShouldBeNil)
+			So(responseBundle, ShouldEqual, responseBody)
+
+			So(rr.Result().StatusCode, ShouldEqual, statusCode)
+
+			for key, value := range headers {
+				So(rr.Header().Get(key), ShouldEqual, value)
+			}
+
+			So(rr.Header().Get(HeaderETag), ShouldEqual, etagValue)
+			So(rr.Header().Get(HeaderCacheControl), ShouldEqual, cacheControl.String())
+		})
+	})
+}
+
+func TestResponseBody(t *testing.T) {
+	testBundle := models.Bundle{
+		BundleType: models.BundleTypeManual,
+		ID:         "testing-bundle",
+	}
+
+	Convey("When type is json", t, func() {
+		responseBody := createResponseBody(ContentTypeJSON, testBundle)
+		Convey("and the body can be marashalled", func() {
+			Convey("Write should write the appropriate body + header", func() {
+				rr := httptest.NewRecorder()
+				responseBody.Write(rr)
+
+				var responseBundle models.Bundle
+				err := json.NewDecoder(rr.Body).Decode(&responseBundle)
+				So(err, ShouldBeNil)
+				So(responseBundle, ShouldEqual, responseBody.body)
+
+				So(rr.Header().Get(HeaderContentType), ShouldEqual, string(ContentTypeJSON))
+			})
+		})
+
+		Convey("and the body cannot be marashalled", func() {
+			responseBody := createResponseBody(ContentTypeJSON, func() {})
+
+			Convey("Write should return an error and not set values", func() {
+				rr := httptest.NewRecorder()
+				err := responseBody.Write(rr)
+
+				So(err, ShouldNotBeNil)
+				var responseBundle models.Bundle
+				err = json.NewDecoder(rr.Body).Decode(&responseBundle)
+				So(err, ShouldNotBeNil)
+
+				So(rr.Header().Get(HeaderContentType), ShouldEqual, string(ContentTypeJSON))
+			})
+		})
+	})
+
+	Convey("When the type is not supported", t, func() {
+		var unsupportedResponseBodyType ContentType = "unsupported"
+
+		responseBody := createResponseBody(unsupportedResponseBodyType, testBundle)
+		Convey("Write should return an error", func() {
+			rr := httptest.NewRecorder()
+			err := responseBody.Write(rr)
+
+			So(err, ShouldNotBeNil)
+			So(err.Error(), ShouldContainSubstring, "not implemented")
+			var responseBundle models.Bundle
+			err = json.NewDecoder(rr.Body).Decode(&responseBundle)
+			So(err, ShouldNotBeNil)
+
+			So(rr.Header().Get(HeaderContentType), ShouldEqual, string(unsupportedResponseBodyType))
+		})
+	})
+}


### PR DESCRIPTION
### What

#### `utils`: Adds various methods + constants for common HTTP request + response handling.

1. Add constants for common headers `utils/headers.go`
2. Add common request methods `utils/requests.go`: route var extraction, ETag validation, JSON body parsing
3. Add a `ResponseBuilder` struct; fluent methods for setting HTTP response vars such as headers, status, response body

#### `apierrors`
   
1. Add various errors 
2. Make strings descriptions constants

#### `models`

1. Add factory methods for creating `Error` + `Event`s
2. Add method for mapping `Code` to a HTTPStatusCode (int)

### How to review

Usual :)

### Who can review

Anyone but me
