### PR TITLE
update GET /bundle-events

### DIFF
--- a/features/steps/steps.go
+++ b/features/steps/steps.go
@@ -121,10 +121,11 @@ func (c *BundleComponent) putBundleEventInDatabase(ctx context.Context, collecti
 	}
 
 	if createdAtStr, ok := event["created_at"].(string); ok {
-		if _, err := time.Parse(time.RFC3339, createdAtStr); err != nil {
+		parsedTime, err := time.Parse(time.RFC3339, createdAtStr)
+		if err != nil {
 			return fmt.Errorf("failed to parse created_at: %w", err)
 		}
-		event["created_at"] = createdAtStr
+		event["created_at"] = parsedTime
 	}
 
 	_, err := c.MongoClient.Connection.Collection(collectionName).InsertOne(ctx, event)

--- a/mongo/bundle_event_store.go
+++ b/mongo/bundle_event_store.go
@@ -42,18 +42,20 @@ func buildListBundleEventsQuery(bundleID string, after, before *time.Time) (filt
 	filter = bson.M{}
 
 	if bundleID != "" {
-		filter["bundle.id"] = bundleID
+
+		filter["$or"] = []bson.M{
+			{"bundle.id": bundleID},
+			{"content_item.bundle_id": bundleID},
+		}
 	}
 
 	if after != nil || before != nil {
 		dateFilter := bson.M{}
 		if after != nil {
-			afterStr := after.Format(time.RFC3339)
-			dateFilter["$gte"] = afterStr
+			dateFilter["$gte"] = *after
 		}
 		if before != nil {
-			beforeStr := before.Format(time.RFC3339)
-			dateFilter["$lte"] = beforeStr
+			dateFilter["$lte"] = *before
 		}
 		filter["created_at"] = dateFilter
 	}


### PR DESCRIPTION
### What

Fix for filtering issues in the db where queries with `?bundle=` and `?before=` or `?after=` parameters were returning 404 in sandbox but working locally due to data structure differences.

As per the swagger spec, Bundle Events can have either a `bundle` or `content_item` field, so the` bundle_id` can potentially sit in either of those. The db query now uses $or to check both field locations.
The db query also now uses proper ISO date objects to check for the `created_at` field, instead of just a string.

### How to review

Run the dataset-catalogue stack
Make a request to `localhost:29800/bundle-events?bundle=bundle-1` and confirm that the correct event is returned
Make requests using the datetime query parameters added - `before`, `after` and ensure these are returning the expected results
Confirm changes make sense

### Who can review

Anyone
