### PR TITLE
Hotfix/add etag get bundle by id endpoint

### DIFF
--- a/api/bundles.go
+++ b/api/bundles.go
@@ -87,7 +87,13 @@ func (api *BundleAPI) getBundle(w http.ResponseWriter, r *http.Request) {
 	// Set the required headers
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Cache-Control", "no-store")
-	dpresponse.SetETag(w, bundle.ETag)
+
+	// Set Etag
+	ETag := bundle.ETag
+	if ETag == "" {
+		ETag = dpresponse.GenerateETag(bundleBytes, false)
+	}
+	dpresponse.SetETag(w, ETag)
 
 	_, err = w.Write(bundleBytes)
 	if err != nil {

--- a/mongo/bundle_event_store.go
+++ b/mongo/bundle_event_store.go
@@ -42,7 +42,6 @@ func buildListBundleEventsQuery(bundleID string, after, before *time.Time) (filt
 	filter = bson.M{}
 
 	if bundleID != "" {
-
 		filter["$or"] = []bson.M{
 			{"bundle.id": bundleID},
 			{"content_item.bundle_id": bundleID},


### PR DESCRIPTION
### What

- Added condition to manually generate ETag if bundle.Etag is empty

### How to review

- GET /bundles/bundle-2
- Check if the ETag header is set when the bundle record e_tag field is empty
- Check if Unit tests are passed
- Check if the build checks are passed

### Who can review

Anyone