### PR TITLE
Feature/create content item delete endpoint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -92,6 +92,9 @@ issues:
     - path: api/contents_test.go
       linters:
         - goconst
+    - path: mongo/bundle_contents_store_test.go
+      linters:
+        - goconst
     # Allow dot import in test files for goconvey
     - path: _test.go
       text: "dot-imports"

--- a/api/api.go
+++ b/api/api.go
@@ -50,6 +50,10 @@ func Setup(ctx context.Context, cfg *config.Config, router *mux.Router, store *s
 		"/bundles/{bundle-id}/contents",
 		authMiddleware.Require("bundles:create", api.postBundleContents),
 	)
+	api.delete(
+		"/bundles/{bundle-id}/contents/{content-id}",
+		authMiddleware.Require("bundles:delete", api.deleteContentItem),
+	)
 
 	return api
 }
@@ -62,4 +66,9 @@ func (api *BundleAPI) get(path string, handler http.HandlerFunc) {
 // post registers a POST http.HandlerFunc.
 func (api *BundleAPI) post(path string, handler http.HandlerFunc) {
 	api.Router.HandleFunc(path, handler).Methods(http.MethodPost)
+}
+
+// delete registers a DELETE http.HandlerFunc.
+func (api *BundleAPI) delete(path string, handler http.HandlerFunc) {
+	api.Router.HandleFunc(path, handler).Methods(http.MethodDelete)
 }

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -18,6 +18,7 @@ func TestSetup(t *testing.T) {
 			So(hasRoute(api.Router, "/bundles", "GET"), ShouldBeTrue)
 			So(hasRoute(api.Router, "/bundles/{bundle-id}", "GET"), ShouldBeTrue)
 			So(hasRoute(api.Router, "/bundles/{bundle-id}/contents", "POST"), ShouldBeTrue)
+			So(hasRoute(api.Router, "/bundles/{bundle-id}/contents/{content-id}", "DELETE"), ShouldBeTrue)
 			So(hasRoute(api.Router, "/bundle-events", "GET"), ShouldBeTrue)
 		})
 	})

--- a/api/contents.go
+++ b/api/contents.go
@@ -309,7 +309,7 @@ func (api *BundleAPI) deleteContentItem(w http.ResponseWriter, r *http.Request) 
 
 	JWTEntityData, err := api.authMiddleware.Parse(strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer "))
 	if err != nil {
-		log.Error(ctx, "postBundleContents endpoint: failed to parse JWT from authorization header", err, logdata)
+		log.Error(ctx, "deleteContentItem endpoint: failed to parse JWT from authorization header", err, logdata)
 		code := models.CodeInternalServerError
 		errInfo := &models.Error{
 			Code:        &code,
@@ -331,7 +331,7 @@ func (api *BundleAPI) deleteContentItem(w http.ResponseWriter, r *http.Request) 
 
 	err = models.ValidateEvent(event)
 	if err != nil {
-		log.Error(ctx, "postBundleContents endpoint: event validation failed", err, logdata)
+		log.Error(ctx, "deleteContentItem endpoint: event validation failed", err, logdata)
 		code := models.CodeInternalServerError
 		errInfo := &models.Error{
 			Code:        &code,
@@ -343,7 +343,7 @@ func (api *BundleAPI) deleteContentItem(w http.ResponseWriter, r *http.Request) 
 
 	err = api.stateMachineBundleAPI.CreateBundleEvent(ctx, event)
 	if err != nil {
-		log.Error(ctx, "postBundleContents endpoint: failed to create event in database", err, logdata)
+		log.Error(ctx, "deleteContentItem endpoint: failed to create event in database", err, logdata)
 		code := models.CodeInternalServerError
 		errInfo := &models.Error{
 			Code:        &code,

--- a/api/contents_test.go
+++ b/api/contents_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net/http"
 	"net/http/httptest"
 	"testing"
 
@@ -886,6 +887,372 @@ func TestPostBundleContents_UpdateBundleETag_Failure(t *testing.T) {
 				},
 			}
 			So(errResp, ShouldResemble, expectedErrResp)
+		})
+	})
+}
+
+func TestDeleteContentItem_Success(t *testing.T) {
+	t.Parallel()
+
+	Convey("Given a DELETE request to /bundles/{bundle-id}/contents/{content-id}", t, func() {
+		r := httptest.NewRequest("DELETE", "/bundles/bundle-1/contents/content-1", http.NoBody)
+		r.Header.Set("Authorization", "test-auth-token")
+		w := httptest.NewRecorder()
+
+		mockedDatastore := &storetest.StorerMock{
+			GetContentItemByBundleIDAndContentItemIDFunc: func(ctx context.Context, bundleID, contentItemID string) (*models.ContentItem, error) {
+				if bundleID == "bundle-1" && contentItemID == "content-1" {
+					return &models.ContentItem{
+						ID:       "content-1",
+						BundleID: "bundle-1",
+					}, nil
+				}
+				return nil, errors.New("content item not found")
+			},
+			DeleteContentItemFunc: func(ctx context.Context, contentItemID string) error {
+				if contentItemID == "content-1" {
+					return nil
+				}
+				return errors.New("failed to delete content item")
+			},
+			CreateBundleEventFunc: func(ctx context.Context, event *models.Event) error {
+				if event.ContentItem.BundleID == "bundle-1" && event.ContentItem.ID == "content-1" {
+					return nil
+				}
+				return errors.New("failed to create bundle event")
+			},
+		}
+
+		bundleAPI := GetBundleAPIWithMocks(store.Datastore{Backend: mockedDatastore})
+
+		Convey("When deleteContentItem is called", func() {
+			bundleAPI.Router.ServeHTTP(w, r)
+
+			Convey("Then it should return a 204 No Content status", func() {
+				So(w.Code, ShouldEqual, 204)
+			})
+
+			Convey("And the response body should be empty", func() {
+				So(w.Body.Len(), ShouldEqual, 0)
+			})
+		})
+	})
+}
+
+func TestDeleteContentItem_ContentItemNotFound_Failure(t *testing.T) {
+	t.Parallel()
+
+	Convey("Given a DELETE request to /bundles/{bundle-id}/contents/{content-id} for a non-existent content item", t, func() {
+		mockedDatastore := &storetest.StorerMock{
+			GetContentItemByBundleIDAndContentItemIDFunc: func(ctx context.Context, bundleID, contentItemID string) (*models.ContentItem, error) {
+				if bundleID == "bundle-1" && contentItemID == "content-1" {
+					return nil, apierrors.ErrContentItemNotFound
+				}
+				return nil, errors.New("unexpected error")
+			},
+		}
+
+		bundleAPI := GetBundleAPIWithMocks(store.Datastore{Backend: mockedDatastore})
+
+		Convey("When deleteContentItem is called with a non-existent content item or bundle", func() {
+			r := httptest.NewRequest("DELETE", "/bundles/bundle-1/contents/content-1", http.NoBody)
+			w := httptest.NewRecorder()
+			bundleAPI.Router.ServeHTTP(w, r)
+
+			Convey("Then it should return a 404 Not Found status code", func() {
+				So(w.Code, ShouldEqual, 404)
+			})
+
+			Convey("And the response body should contain an error message", func() {
+				var errResp models.ErrorList
+				err := json.NewDecoder(w.Body).Decode(&errResp)
+				So(err, ShouldBeNil)
+
+				codeNotFound := models.CodeNotFound
+				expectedErrResp := models.ErrorList{
+					Errors: []*models.Error{
+						{
+							Code:        &codeNotFound,
+							Description: apierrors.ErrorDescriptionNotFound,
+						},
+					},
+				}
+				So(errResp, ShouldResemble, expectedErrResp)
+			})
+		})
+
+		Convey("When deleteContentItem is called and the GetContentItemByBundleIDAndContentItemID fails", func() {
+			r := httptest.NewRequest("DELETE", "/bundles/bundle-0/contents/content-0", http.NoBody)
+			w := httptest.NewRecorder()
+			bundleAPI.Router.ServeHTTP(w, r)
+
+			Convey("Then it should return a 500 Internal Server Error status code", func() {
+				So(w.Code, ShouldEqual, 500)
+			})
+
+			Convey("And the response body should contain an error message", func() {
+				var errResp models.ErrorList
+				err := json.NewDecoder(w.Body).Decode(&errResp)
+				So(err, ShouldBeNil)
+
+				codeInternalServerError := models.CodeInternalServerError
+				expectedErrResp := models.ErrorList{
+					Errors: []*models.Error{
+						{
+							Code:        &codeInternalServerError,
+							Description: apierrors.ErrorDescriptionInternalError,
+						},
+					},
+				}
+				So(errResp, ShouldResemble, expectedErrResp)
+			})
+		})
+	})
+}
+
+func TestDeleteContentItem_ContentItemIsPublished_Failure(t *testing.T) {
+	t.Parallel()
+
+	Convey("Given a DELETE request to /bundles/{bundle-id}/contents/{content-id} for a published content item", t, func() {
+		r := httptest.NewRequest("DELETE", "/bundles/bundle-1/contents/content-1", http.NoBody)
+		w := httptest.NewRecorder()
+
+		publishedState := models.StatePublished
+
+		mockedDatastore := &storetest.StorerMock{
+			GetContentItemByBundleIDAndContentItemIDFunc: func(ctx context.Context, bundleID, contentItemID string) (*models.ContentItem, error) {
+				if bundleID == "bundle-1" && contentItemID == "content-1" {
+					return &models.ContentItem{
+						ID:       "content-1",
+						BundleID: "bundle-1",
+						State:    &publishedState,
+					}, nil
+				}
+				return nil, apierrors.ErrContentItemNotFound
+			},
+		}
+
+		bundleAPI := GetBundleAPIWithMocks(store.Datastore{Backend: mockedDatastore})
+
+		Convey("When deleteContentItem is called for a published content item", func() {
+			bundleAPI.Router.ServeHTTP(w, r)
+
+			Convey("Then it should return a 409 Conflict status code", func() {
+				So(w.Code, ShouldEqual, 409)
+			})
+
+			Convey("And the response body should contain an error message", func() {
+				var errResp models.ErrorList
+				err := json.NewDecoder(w.Body).Decode(&errResp)
+				So(err, ShouldBeNil)
+
+				codeConflict := models.CodeConflict
+				expectedErrResp := models.ErrorList{
+					Errors: []*models.Error{
+						{
+							Code:        &codeConflict,
+							Description: apierrors.ErrorDescriptionContentItemAlreadyPublished,
+						},
+					},
+				}
+				So(errResp, ShouldResemble, expectedErrResp)
+			})
+		})
+	})
+}
+
+func TestDeleteContentItem_DeleteContentItem_Failure(t *testing.T) {
+	t.Parallel()
+
+	Convey("Given a DELETE request to /bundles/{bundle-id}/contents/{content-id}", t, func() {
+		mockedDatastore := &storetest.StorerMock{
+			GetContentItemByBundleIDAndContentItemIDFunc: func(ctx context.Context, bundleID, contentItemID string) (*models.ContentItem, error) {
+				if bundleID == "bundle-1" && contentItemID == "content-1" {
+					return &models.ContentItem{
+						ID:       "content-1",
+						BundleID: "bundle-1",
+					}, nil
+				}
+				if bundleID == "bundle-1" && contentItemID == "content-2" {
+					return &models.ContentItem{
+						ID:       "content-2",
+						BundleID: "bundle-1",
+					}, nil
+				}
+				return nil, apierrors.ErrContentItemNotFound
+			},
+			DeleteContentItemFunc: func(ctx context.Context, contentItemID string) error {
+				if contentItemID == "content-1" {
+					return apierrors.ErrContentItemNotFound
+				}
+				if contentItemID == "content-2" {
+					return errors.New("failed to delete content item")
+				}
+				return nil
+			},
+		}
+
+		bundleAPI := GetBundleAPIWithMocks(store.Datastore{Backend: mockedDatastore})
+
+		Convey("When deleteContentItem is called and the content item is not found", func() {
+			r := httptest.NewRequest("DELETE", "/bundles/bundle-1/contents/content-1", http.NoBody)
+			w := httptest.NewRecorder()
+			bundleAPI.Router.ServeHTTP(w, r)
+
+			Convey("Then it should return a 404 Not Found status code", func() {
+				So(w.Code, ShouldEqual, 404)
+			})
+
+			Convey("And the response body should contain an error message", func() {
+				var errResp models.ErrorList
+				err := json.NewDecoder(w.Body).Decode(&errResp)
+				So(err, ShouldBeNil)
+
+				codeNotFound := models.CodeNotFound
+				expectedErrResp := models.ErrorList{
+					Errors: []*models.Error{
+						{
+							Code:        &codeNotFound,
+							Description: apierrors.ErrorDescriptionNotFound,
+						},
+					},
+				}
+				So(errResp, ShouldResemble, expectedErrResp)
+			})
+		})
+
+		Convey("When deleteContentItem is called and the DeleteContentItem fails", func() {
+			r := httptest.NewRequest("DELETE", "/bundles/bundle-1/contents/content-2", http.NoBody)
+			w := httptest.NewRecorder()
+			bundleAPI.Router.ServeHTTP(w, r)
+
+			Convey("Then it should return a 500 Internal Server Error status code", func() {
+				So(w.Code, ShouldEqual, 500)
+			})
+
+			Convey("And the response body should contain an error message", func() {
+				var errResp models.ErrorList
+				err := json.NewDecoder(w.Body).Decode(&errResp)
+				So(err, ShouldBeNil)
+
+				codeInternalServerError := models.CodeInternalServerError
+				expectedErrResp := models.ErrorList{
+					Errors: []*models.Error{
+						{
+							Code:        &codeInternalServerError,
+							Description: apierrors.ErrorDescriptionInternalError,
+						},
+					},
+				}
+				So(errResp, ShouldResemble, expectedErrResp)
+			})
+		})
+	})
+}
+
+func TestDeleteContentItem_ParseJWT_Failure(t *testing.T) {
+	t.Parallel()
+
+	Convey("Given a DELETE request to /bundles/{bundle-id}/contents/{content-id} and parsing the JWT fails", t, func() {
+		r := httptest.NewRequest("DELETE", "/bundles/bundle-1/contents/content-1", http.NoBody)
+		r.Header.Set("Authorization", "invalid-auth-token")
+		w := httptest.NewRecorder()
+
+		mockedDatastore := &storetest.StorerMock{
+			GetContentItemByBundleIDAndContentItemIDFunc: func(ctx context.Context, bundleID, contentItemID string) (*models.ContentItem, error) {
+				if bundleID == "bundle-1" && contentItemID == "content-1" {
+					return &models.ContentItem{
+						ID:       "content-1",
+						BundleID: "bundle-1",
+					}, nil
+				}
+				return nil, errors.New("content item not found")
+			},
+			DeleteContentItemFunc: func(ctx context.Context, contentItemID string) error {
+				if contentItemID == "content-1" {
+					return nil
+				}
+				return errors.New("failed to delete content item")
+			},
+		}
+
+		bundleAPI := GetBundleAPIWithMocks(store.Datastore{Backend: mockedDatastore})
+
+		Convey("When deleteContentItem is called", func() {
+			bundleAPI.Router.ServeHTTP(w, r)
+
+			var errResp models.ErrorList
+			err := json.NewDecoder(w.Body).Decode(&errResp)
+			So(err, ShouldBeNil)
+
+			codeInternalServerError := models.CodeInternalServerError
+			expectedErrResp := models.ErrorList{
+				Errors: []*models.Error{
+					{
+						Code:        &codeInternalServerError,
+						Description: apierrors.ErrorDescriptionInternalError,
+					},
+				},
+			}
+			So(errResp, ShouldResemble, expectedErrResp)
+		})
+	})
+}
+
+func TestDeleteContentItem_CreateBundleEvent_Failure(t *testing.T) {
+	t.Parallel()
+
+	Convey("Given a DELETE request to /bundles/{bundle-id}/contents/{content-id} and bundle event creation fails", t, func() {
+		r := httptest.NewRequest("DELETE", "/bundles/bundle-1/contents/content-1", http.NoBody)
+		r.Header.Set("Authorization", "test-auth-token")
+		w := httptest.NewRecorder()
+
+		mockedDatastore := &storetest.StorerMock{
+			GetContentItemByBundleIDAndContentItemIDFunc: func(ctx context.Context, bundleID, contentItemID string) (*models.ContentItem, error) {
+				if bundleID == "bundle-1" && contentItemID == "content-1" {
+					return &models.ContentItem{
+						ID:       "content-1",
+						BundleID: "bundle-1",
+					}, nil
+				}
+				return nil, apierrors.ErrContentItemNotFound
+			},
+			DeleteContentItemFunc: func(ctx context.Context, contentItemID string) error {
+				if contentItemID == "content-1" {
+					return nil
+				}
+				return errors.New("failed to delete content item")
+			},
+			CreateBundleEventFunc: func(ctx context.Context, event *models.Event) error {
+				return errors.New("failed to create bundle event")
+			},
+		}
+
+		bundleAPI := GetBundleAPIWithMocks(store.Datastore{Backend: mockedDatastore})
+
+		Convey("When deleteContentItem is called", func() {
+			bundleAPI.Router.ServeHTTP(w, r)
+
+			Convey("Then it should return a 500 Internal Server Error status code", func() {
+				So(w.Code, ShouldEqual, 500)
+			})
+
+			Convey("And the response body should contain an error message", func() {
+				var errResp models.ErrorList
+				err := json.NewDecoder(w.Body).Decode(&errResp)
+				So(err, ShouldBeNil)
+
+				codeInternalServerError := models.CodeInternalServerError
+				expectedErrResp := models.ErrorList{
+					Errors: []*models.Error{
+						{
+							Code:        &codeInternalServerError,
+							Description: apierrors.ErrorDescriptionInternalError,
+						},
+					},
+				}
+				So(errResp, ShouldResemble, expectedErrResp)
+			})
 		})
 	})
 }

--- a/apierrors/errors.go
+++ b/apierrors/errors.go
@@ -13,10 +13,11 @@ func (e ErrInvalidPatch) Error() string {
 
 // Response error descriptions
 var (
-	ErrorDescriptionMalformedRequest  = "Unable to process request due to a malformed or invalid request body or query parameter"
-	ErrorDescriptionMissingParameters = "Unable to process request due to missing required parameters in the request body or query parameters"
-	ErrorDescriptionNotFound          = "The requested resource does not exist"
-	ErrorDescriptionInternalError     = "Failed to process the request due to an internal error"
+	ErrorDescriptionMalformedRequest            = "Unable to process request due to a malformed or invalid request body or query parameter"
+	ErrorDescriptionMissingParameters           = "Unable to process request due to missing required parameters in the request body or query parameters"
+	ErrorDescriptionNotFound                    = "The requested resource does not exist"
+	ErrorDescriptionInternalError               = "Failed to process the request due to an internal error"
+	ErrorDescriptionContentItemAlreadyPublished = "Change rejected due to a conflict with the current resource state. A common cause is attempting to change a bundle that is already locked pending publication or has already been published."
 )
 
 var (
@@ -47,6 +48,9 @@ var (
 	ErrInvalidBundleReference = errors.New("invalid bundle reference")
 	ErrBundleEventNotFound    = errors.New("bundle event not found")
 
+	// Content-Specific
+	ErrContentItemNotFound = errors.New("content item not found")
+
 	// Validation
 	ErrMissingParameters      = errors.New("missing required parameters in request")
 	ErrInvalidQueryParameter  = errors.New("invalid query parameter")
@@ -61,6 +65,7 @@ var (
 var NotFoundMap = map[error]bool{
 	ErrBundleNotFound:      true,
 	ErrBundleEventNotFound: true,
+	ErrContentItemNotFound: true,
 }
 
 // 400 Bad Request

--- a/application/application.go
+++ b/application/application.go
@@ -45,6 +45,10 @@ func (s *StateMachineBundleAPI) CreateContentItem(ctx context.Context, contentIt
 	return s.Datastore.CreateContentItem(ctx, contentItem)
 }
 
+func (s *StateMachineBundleAPI) GetContentItemByBundleIDAndContentItemID(ctx context.Context, bundleID, contentItemID string) (*models.ContentItem, error) {
+	return s.Datastore.GetContentItemByBundleIDAndContentItemID(ctx, bundleID, contentItemID)
+}
+
 func (s *StateMachineBundleAPI) ListBundleEvents(ctx context.Context, offset, limit int, bundleID string, after, before *time.Time) ([]*models.Event, int, error) {
 	results, totalCount, err := s.Datastore.ListBundleEvents(ctx, offset, limit, bundleID, after, before)
 	if err != nil {
@@ -59,6 +63,10 @@ func (s *StateMachineBundleAPI) CheckAllBundleContentsAreApproved(ctx context.Co
 
 func (s *StateMachineBundleAPI) CheckContentItemExistsByDatasetEditionVersion(ctx context.Context, datasetID, editionID string, versionID int) (bool, error) {
 	return s.Datastore.CheckContentItemExistsByDatasetEditionVersion(ctx, datasetID, editionID, versionID)
+}
+
+func (s *StateMachineBundleAPI) DeleteContentItem(ctx context.Context, contentItemID string) error {
+	return s.Datastore.DeleteContentItem(ctx, contentItemID)
 }
 
 func (s *StateMachineBundleAPI) CreateBundleEvent(ctx context.Context, event *models.Event) error {

--- a/features/contents_add.feature
+++ b/features/contents_add.feature
@@ -10,7 +10,7 @@ Feature: Add a dataset item to a bundle - POST /bundles/{id}/contents
                 "created_by": {
                     "email": "publisher@ons.gov.uk"
                 },
-                "created_at": "2025-06-09T07:00:00Z",
+                "created_at": "2025-01-01T07:00:00Z",
                 "last_updated_by": {
                     "email": "publisher@ons.gov.uk"
                 },
@@ -19,10 +19,10 @@ Feature: Add a dataset item to a bundle - POST /bundles/{id}/contents
                         "id": "890m231k-98df-11ec-b909-0242ac120002"
                     }
                 ],
-                "scheduled_at": "2025-05-05T08:00:00Z",
+                "scheduled_at": "2025-01-03T07:00:00Z",
                 "state": "DRAFT",
                 "title": "bundle-1",
-                "updated_at": "2025-06-10T07:00:00Z",
+                "updated_at": "2025-01-02T07:00:00Z",
                 "managed_by": "WAGTAIL",
                 "e_tag": "original-etag"
             }

--- a/features/contents_delete.feature
+++ b/features/contents_delete.feature
@@ -1,0 +1,147 @@
+Feature: Delete a content item from a bundle - POST /bundles/{bundle-id}/contents/{content-id}
+
+    Background:
+        Given I have these bundles:
+        """
+        [
+            {
+                "id": "bundle-1",
+                "bundle_type": "SCHEDULED",
+                "created_by": {
+                    "email": "publisher@ons.gov.uk"
+                },
+                "created_at": "2025-01-01T07:00:00Z",
+                "last_updated_by": {
+                    "email": "publisher@ons.gov.uk"
+                },
+                "preview_teams": [
+                    {
+                        "id": "890m231k-98df-11ec-b909-0242ac120002"
+                    }
+                ],
+                "scheduled_at": "2025-01-03T07:00:00Z",
+                "state": "DRAFT",
+                "title": "bundle-1",
+                "updated_at": "2025-01-02T07:00:00Z",
+                "managed_by": "WAGTAIL",
+                "e_tag": "original-etag"
+            },
+            {
+                "id": "bundle-2",
+                "bundle_type": "SCHEDULED",
+                "created_by": {
+                    "email": "publisher@ons.gov.uk"
+                },
+                "created_at": "2025-01-04T07:00:00Z",
+                "last_updated_by": {
+                    "email": "publisher@ons.gov.uk"
+                },
+                "preview_teams": [
+                    {
+                        "id": "890m231k-98df-11ec-b909-0242ac120002"
+                    }
+                ],
+                "scheduled_at": "2025-01-06T07:00:00Z",
+                "state": "PUBLISHED",
+                "title": "bundle-1",
+                "updated_at": "2025-01-06T07:00:00Z",
+                "managed_by": "WAGTAIL",
+                "e_tag": "original-etag"
+            }
+        ]
+        """
+        And I have these content items:
+        """
+        [
+            {
+                "id": "content-item-1",
+                "bundle_id": "bundle-1",
+                "content_type": "DATASET",
+                "metadata": {
+                    "dataset_id": "dataset1",
+                    "edition_id": "edition1",
+                    "version_id": 1,
+                    "title": "Test Dataset 1"
+                },
+                "links": {
+                    "edit": "edit/link",
+                    "preview": "preview/link"
+                }
+            },
+            {
+                "id": "content-item-2",
+                "bundle_id": "bundle-2",
+                "content_type": "DATASET",
+                "metadata": {
+                    "dataset_id": "dataset2",
+                    "edition_id": "edition2",
+                    "version_id": 2,
+                    "title": "Test Dataset 2"
+                },
+                "links": {
+                    "edit": "edit/link",
+                    "preview": "preview/link"
+                },
+                "state": "PUBLISHED"
+            }
+        ]
+        """
+
+    Scenario: DELETE /bundles/{bundle-id}/contents/{content-id} successfully
+        Given I am an admin user
+        When I DELETE "/bundles/bundle-1/contents/content-item-1"
+        Then the HTTP status code should be "204"
+        And the content item in the database for id "content-item-1" should not exist
+    
+    Scenario: DELETE /bundles/{bundle-id}/contents/{content-id} with non-existent bundle
+        Given I am an admin user
+        When I DELETE "/bundles/bundle-3/contents/content-item-1"
+        Then I should receive the following JSON response with status "404":
+            """
+            {
+                "errors": [
+                    {
+                        "code": "not_found",
+                        "description": "The requested resource does not exist"
+                    }
+                ]
+            }
+            """
+
+    Scenario: DELETE /bundles/{bundle-id}/contents/{content-id} with non-existent content item
+        Given I am an admin user
+        When I DELETE "/bundles/bundle-1/contents/content-item-3"
+        Then I should receive the following JSON response with status "404":
+            """
+            {
+                "errors": [
+                    {
+                        "code": "not_found",
+                        "description": "The requested resource does not exist"
+                    }
+                ]
+            }
+            """
+
+    Scenario: DELETE /bundles/{bundle-id}/contents/{content-id} with a content item that is published
+        Given I am an admin user
+        When I DELETE "/bundles/bundle-2/contents/content-item-2"
+        Then I should receive the following JSON response with status "409":
+            """
+            {
+                "errors": [
+                    {
+                        "code": "conflict",
+                        "description": "Change rejected due to a conflict with the current resource state. A common cause is attempting to change a bundle that is already locked pending publication or has already been published."
+                    }
+                ]
+            }
+            """
+
+    Scenario: DELETE /bundles/{bundle-id}/contents/{content-id} with no authentication
+        Given I am not authenticated
+        When I DELETE "/bundles/bundle-1/contents/content-item-1"
+        Then the HTTP status code should be "401"
+        And the response body should be empty
+
+    

--- a/features/steps/bundle_component.go
+++ b/features/steps/bundle_component.go
@@ -122,6 +122,13 @@ func getPermissionsBundle() *permissionsSDK.Bundle {
 				},
 			},
 		},
+		"bundles:delete": {
+			"groups/role-admin": {
+				{
+					ID: "1",
+				},
+			},
+		},
 	}
 }
 

--- a/models/content.go
+++ b/models/content.go
@@ -11,7 +11,7 @@ import (
 
 // ContentItem represents information about the datasets to be published as part of the bundle
 type ContentItem struct {
-	ID          string      `bson:"id,omitempty"    json:"id,omitempty"`
+	ID          string      `bson:"id"              json:"id"`
 	BundleID    string      `bson:"bundle_id"       json:"bundle_id"`
 	ContentType ContentType `bson:"content_type"    json:"content_type"`
 	Metadata    Metadata    `bson:"metadata"        json:"metadata"`

--- a/mongo/bundle_contents_store.go
+++ b/mongo/bundle_contents_store.go
@@ -2,11 +2,34 @@ package mongo
 
 import (
 	"context"
+	"errors"
 
+	"github.com/ONSdigital/dis-bundle-api/apierrors"
 	"github.com/ONSdigital/dis-bundle-api/config"
 	"github.com/ONSdigital/dis-bundle-api/models"
+	mongodriver "github.com/ONSdigital/dp-mongodb/v3/mongodb"
 	"go.mongodb.org/mongo-driver/bson"
 )
+
+// GetContentItemByBundleIDAndContentItemID retrieves a content item by bundle ID and content item ID
+func (m *Mongo) GetContentItemByBundleIDAndContentItemID(ctx context.Context, bundleID, contentItemID string) (*models.ContentItem, error) {
+	filter := bson.M{
+		"id":        contentItemID,
+		"bundle_id": bundleID,
+	}
+
+	var result models.ContentItem
+	err := m.Connection.Collection(m.ActualCollectionName(config.BundleContentsCollection)).
+		FindOne(ctx, filter, &result)
+
+	if err != nil {
+		if errors.Is(err, mongodriver.ErrNoDocumentFound) {
+			return nil, apierrors.ErrContentItemNotFound
+		}
+		return nil, err
+	}
+	return &result, nil
+}
 
 // CreateContentItem inserts a new content item into the database
 func (m *Mongo) CreateContentItem(ctx context.Context, contentItem *models.ContentItem) error {
@@ -46,4 +69,20 @@ func (m *Mongo) CheckContentItemExistsByDatasetEditionVersion(ctx context.Contex
 	}
 
 	return count > 0, nil
+}
+
+// DeleteContentItem removes a content item by its ID
+func (m *Mongo) DeleteContentItem(ctx context.Context, contentItemID string) error {
+	result, err := m.Connection.Collection(m.ActualCollectionName(config.BundleContentsCollection)).
+		DeleteOne(ctx, bson.M{"id": contentItemID})
+
+	if err != nil {
+		return err
+	}
+
+	if result.DeletedCount == 0 {
+		return apierrors.ErrContentItemNotFound
+	}
+
+	return nil
 }

--- a/store/datastore.go
+++ b/store/datastore.go
@@ -24,9 +24,11 @@ type dataMongoDB interface {
 	GetBundle(ctx context.Context, bundleID string) (*models.Bundle, error)
 	UpdateBundleETag(ctx context.Context, bundleID, email string) (*models.Bundle, error)
 	CheckBundleExists(ctx context.Context, bundleID string) (bool, error)
+	GetContentItemByBundleIDAndContentItemID(ctx context.Context, bundleID, contentItemID string) (*models.ContentItem, error)
 	CreateContentItem(ctx context.Context, contentItem *models.ContentItem) error
 	CheckAllBundleContentsAreApproved(ctx context.Context, bundleID string) (bool, error)
 	CheckContentItemExistsByDatasetEditionVersion(ctx context.Context, datasetID, editionID string, versionID int) (bool, error)
+	DeleteContentItem(ctx context.Context, contentItemID string) error
 	CreateBundleEvent(ctx context.Context, event *models.Event) error
 	Checker(ctx context.Context, state *healthcheck.CheckState) error
 	Close(ctx context.Context) error
@@ -63,6 +65,10 @@ func (ds *Datastore) CheckBundleExists(ctx context.Context, bundleID string) (bo
 	return ds.Backend.CheckBundleExists(ctx, bundleID)
 }
 
+func (ds *Datastore) GetContentItemByBundleIDAndContentItemID(ctx context.Context, bundleID, contentItemID string) (*models.ContentItem, error) {
+	return ds.Backend.GetContentItemByBundleIDAndContentItemID(ctx, bundleID, contentItemID)
+}
+
 func (ds *Datastore) CreateContentItem(ctx context.Context, contentItem *models.ContentItem) error {
 	return ds.Backend.CreateContentItem(ctx, contentItem)
 }
@@ -73,6 +79,10 @@ func (ds *Datastore) CheckAllBundleContentsAreApproved(ctx context.Context, bund
 
 func (ds *Datastore) CheckContentItemExistsByDatasetEditionVersion(ctx context.Context, datasetID, editionID string, versionID int) (bool, error) {
 	return ds.Backend.CheckContentItemExistsByDatasetEditionVersion(ctx, datasetID, editionID, versionID)
+}
+
+func (ds *Datastore) DeleteContentItem(ctx context.Context, contentItemID string) error {
+	return ds.Backend.DeleteContentItem(ctx, contentItemID)
 }
 
 func (ds *Datastore) CreateBundleEvent(ctx context.Context, event *models.Event) error {

--- a/store/datastoretest/datastore.go
+++ b/store/datastoretest/datastore.go
@@ -44,8 +44,14 @@ var _ store.Storer = &StorerMock{}
 //			CreateContentItemFunc: func(ctx context.Context, contentItem *models.ContentItem) error {
 //				panic("mock out the CreateContentItem method")
 //			},
+//			DeleteContentItemFunc: func(ctx context.Context, contentItemID string) error {
+//				panic("mock out the DeleteContentItem method")
+//			},
 //			GetBundleFunc: func(ctx context.Context, bundleID string) (*models.Bundle, error) {
 //				panic("mock out the GetBundle method")
+//			},
+//			GetContentItemByBundleIDAndContentItemIDFunc: func(ctx context.Context, bundleID string, contentItemID string) (*models.ContentItem, error) {
+//				panic("mock out the GetContentItemByBundleIDAndContentItemID method")
 //			},
 //			ListBundleEventsFunc: func(ctx context.Context, offset int, limit int, bundleID string, after *time.Time, before *time.Time) ([]*models.Event, int, error) {
 //				panic("mock out the ListBundleEvents method")
@@ -84,8 +90,14 @@ type StorerMock struct {
 	// CreateContentItemFunc mocks the CreateContentItem method.
 	CreateContentItemFunc func(ctx context.Context, contentItem *models.ContentItem) error
 
+	// DeleteContentItemFunc mocks the DeleteContentItem method.
+	DeleteContentItemFunc func(ctx context.Context, contentItemID string) error
+
 	// GetBundleFunc mocks the GetBundle method.
 	GetBundleFunc func(ctx context.Context, bundleID string) (*models.Bundle, error)
+
+	// GetContentItemByBundleIDAndContentItemIDFunc mocks the GetContentItemByBundleIDAndContentItemID method.
+	GetContentItemByBundleIDAndContentItemIDFunc func(ctx context.Context, bundleID string, contentItemID string) (*models.ContentItem, error)
 
 	// ListBundleEventsFunc mocks the ListBundleEvents method.
 	ListBundleEventsFunc func(ctx context.Context, offset int, limit int, bundleID string, after *time.Time, before *time.Time) ([]*models.Event, int, error)
@@ -149,12 +161,28 @@ type StorerMock struct {
 			// ContentItem is the contentItem argument value.
 			ContentItem *models.ContentItem
 		}
+		// DeleteContentItem holds details about calls to the DeleteContentItem method.
+		DeleteContentItem []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// ContentItemID is the contentItemID argument value.
+			ContentItemID string
+		}
 		// GetBundle holds details about calls to the GetBundle method.
 		GetBundle []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
 			// BundleID is the bundleID argument value.
 			BundleID string
+		}
+		// GetContentItemByBundleIDAndContentItemID holds details about calls to the GetContentItemByBundleIDAndContentItemID method.
+		GetContentItemByBundleIDAndContentItemID []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// BundleID is the bundleID argument value.
+			BundleID string
+			// ContentItemID is the contentItemID argument value.
+			ContentItemID string
 		}
 		// ListBundleEvents holds details about calls to the ListBundleEvents method.
 		ListBundleEvents []struct {
@@ -199,7 +227,9 @@ type StorerMock struct {
 	lockClose                                         sync.RWMutex
 	lockCreateBundleEvent                             sync.RWMutex
 	lockCreateContentItem                             sync.RWMutex
+	lockDeleteContentItem                             sync.RWMutex
 	lockGetBundle                                     sync.RWMutex
+	lockGetContentItemByBundleIDAndContentItemID      sync.RWMutex
 	lockListBundleEvents                              sync.RWMutex
 	lockListBundles                                   sync.RWMutex
 	lockUpdateBundleETag                              sync.RWMutex
@@ -461,6 +491,42 @@ func (mock *StorerMock) CreateContentItemCalls() []struct {
 	return calls
 }
 
+// DeleteContentItem calls DeleteContentItemFunc.
+func (mock *StorerMock) DeleteContentItem(ctx context.Context, contentItemID string) error {
+	if mock.DeleteContentItemFunc == nil {
+		panic("StorerMock.DeleteContentItemFunc: method is nil but Storer.DeleteContentItem was just called")
+	}
+	callInfo := struct {
+		Ctx           context.Context
+		ContentItemID string
+	}{
+		Ctx:           ctx,
+		ContentItemID: contentItemID,
+	}
+	mock.lockDeleteContentItem.Lock()
+	mock.calls.DeleteContentItem = append(mock.calls.DeleteContentItem, callInfo)
+	mock.lockDeleteContentItem.Unlock()
+	return mock.DeleteContentItemFunc(ctx, contentItemID)
+}
+
+// DeleteContentItemCalls gets all the calls that were made to DeleteContentItem.
+// Check the length with:
+//
+//	len(mockedStorer.DeleteContentItemCalls())
+func (mock *StorerMock) DeleteContentItemCalls() []struct {
+	Ctx           context.Context
+	ContentItemID string
+} {
+	var calls []struct {
+		Ctx           context.Context
+		ContentItemID string
+	}
+	mock.lockDeleteContentItem.RLock()
+	calls = mock.calls.DeleteContentItem
+	mock.lockDeleteContentItem.RUnlock()
+	return calls
+}
+
 // GetBundle calls GetBundleFunc.
 func (mock *StorerMock) GetBundle(ctx context.Context, bundleID string) (*models.Bundle, error) {
 	if mock.GetBundleFunc == nil {
@@ -494,6 +560,46 @@ func (mock *StorerMock) GetBundleCalls() []struct {
 	mock.lockGetBundle.RLock()
 	calls = mock.calls.GetBundle
 	mock.lockGetBundle.RUnlock()
+	return calls
+}
+
+// GetContentItemByBundleIDAndContentItemID calls GetContentItemByBundleIDAndContentItemIDFunc.
+func (mock *StorerMock) GetContentItemByBundleIDAndContentItemID(ctx context.Context, bundleID string, contentItemID string) (*models.ContentItem, error) {
+	if mock.GetContentItemByBundleIDAndContentItemIDFunc == nil {
+		panic("StorerMock.GetContentItemByBundleIDAndContentItemIDFunc: method is nil but Storer.GetContentItemByBundleIDAndContentItemID was just called")
+	}
+	callInfo := struct {
+		Ctx           context.Context
+		BundleID      string
+		ContentItemID string
+	}{
+		Ctx:           ctx,
+		BundleID:      bundleID,
+		ContentItemID: contentItemID,
+	}
+	mock.lockGetContentItemByBundleIDAndContentItemID.Lock()
+	mock.calls.GetContentItemByBundleIDAndContentItemID = append(mock.calls.GetContentItemByBundleIDAndContentItemID, callInfo)
+	mock.lockGetContentItemByBundleIDAndContentItemID.Unlock()
+	return mock.GetContentItemByBundleIDAndContentItemIDFunc(ctx, bundleID, contentItemID)
+}
+
+// GetContentItemByBundleIDAndContentItemIDCalls gets all the calls that were made to GetContentItemByBundleIDAndContentItemID.
+// Check the length with:
+//
+//	len(mockedStorer.GetContentItemByBundleIDAndContentItemIDCalls())
+func (mock *StorerMock) GetContentItemByBundleIDAndContentItemIDCalls() []struct {
+	Ctx           context.Context
+	BundleID      string
+	ContentItemID string
+} {
+	var calls []struct {
+		Ctx           context.Context
+		BundleID      string
+		ContentItemID string
+	}
+	mock.lockGetContentItemByBundleIDAndContentItemID.RLock()
+	calls = mock.calls.GetContentItemByBundleIDAndContentItemID
+	mock.lockGetContentItemByBundleIDAndContentItemID.RUnlock()
 	return calls
 }
 

--- a/store/datastoretest/mongo.go
+++ b/store/datastoretest/mongo.go
@@ -44,8 +44,14 @@ var _ store.MongoDB = &MongoDBMock{}
 //			CreateContentItemFunc: func(ctx context.Context, contentItem *models.ContentItem) error {
 //				panic("mock out the CreateContentItem method")
 //			},
+//			DeleteContentItemFunc: func(ctx context.Context, contentItemID string) error {
+//				panic("mock out the DeleteContentItem method")
+//			},
 //			GetBundleFunc: func(ctx context.Context, bundleID string) (*models.Bundle, error) {
 //				panic("mock out the GetBundle method")
+//			},
+//			GetContentItemByBundleIDAndContentItemIDFunc: func(ctx context.Context, bundleID string, contentItemID string) (*models.ContentItem, error) {
+//				panic("mock out the GetContentItemByBundleIDAndContentItemID method")
 //			},
 //			ListBundleEventsFunc: func(ctx context.Context, offset int, limit int, bundleID string, after *time.Time, before *time.Time) ([]*models.Event, int, error) {
 //				panic("mock out the ListBundleEvents method")
@@ -84,8 +90,14 @@ type MongoDBMock struct {
 	// CreateContentItemFunc mocks the CreateContentItem method.
 	CreateContentItemFunc func(ctx context.Context, contentItem *models.ContentItem) error
 
+	// DeleteContentItemFunc mocks the DeleteContentItem method.
+	DeleteContentItemFunc func(ctx context.Context, contentItemID string) error
+
 	// GetBundleFunc mocks the GetBundle method.
 	GetBundleFunc func(ctx context.Context, bundleID string) (*models.Bundle, error)
+
+	// GetContentItemByBundleIDAndContentItemIDFunc mocks the GetContentItemByBundleIDAndContentItemID method.
+	GetContentItemByBundleIDAndContentItemIDFunc func(ctx context.Context, bundleID string, contentItemID string) (*models.ContentItem, error)
 
 	// ListBundleEventsFunc mocks the ListBundleEvents method.
 	ListBundleEventsFunc func(ctx context.Context, offset int, limit int, bundleID string, after *time.Time, before *time.Time) ([]*models.Event, int, error)
@@ -149,12 +161,28 @@ type MongoDBMock struct {
 			// ContentItem is the contentItem argument value.
 			ContentItem *models.ContentItem
 		}
+		// DeleteContentItem holds details about calls to the DeleteContentItem method.
+		DeleteContentItem []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// ContentItemID is the contentItemID argument value.
+			ContentItemID string
+		}
 		// GetBundle holds details about calls to the GetBundle method.
 		GetBundle []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
 			// BundleID is the bundleID argument value.
 			BundleID string
+		}
+		// GetContentItemByBundleIDAndContentItemID holds details about calls to the GetContentItemByBundleIDAndContentItemID method.
+		GetContentItemByBundleIDAndContentItemID []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// BundleID is the bundleID argument value.
+			BundleID string
+			// ContentItemID is the contentItemID argument value.
+			ContentItemID string
 		}
 		// ListBundleEvents holds details about calls to the ListBundleEvents method.
 		ListBundleEvents []struct {
@@ -199,7 +227,9 @@ type MongoDBMock struct {
 	lockClose                                         sync.RWMutex
 	lockCreateBundleEvent                             sync.RWMutex
 	lockCreateContentItem                             sync.RWMutex
+	lockDeleteContentItem                             sync.RWMutex
 	lockGetBundle                                     sync.RWMutex
+	lockGetContentItemByBundleIDAndContentItemID      sync.RWMutex
 	lockListBundleEvents                              sync.RWMutex
 	lockListBundles                                   sync.RWMutex
 	lockUpdateBundleETag                              sync.RWMutex
@@ -461,6 +491,42 @@ func (mock *MongoDBMock) CreateContentItemCalls() []struct {
 	return calls
 }
 
+// DeleteContentItem calls DeleteContentItemFunc.
+func (mock *MongoDBMock) DeleteContentItem(ctx context.Context, contentItemID string) error {
+	if mock.DeleteContentItemFunc == nil {
+		panic("MongoDBMock.DeleteContentItemFunc: method is nil but MongoDB.DeleteContentItem was just called")
+	}
+	callInfo := struct {
+		Ctx           context.Context
+		ContentItemID string
+	}{
+		Ctx:           ctx,
+		ContentItemID: contentItemID,
+	}
+	mock.lockDeleteContentItem.Lock()
+	mock.calls.DeleteContentItem = append(mock.calls.DeleteContentItem, callInfo)
+	mock.lockDeleteContentItem.Unlock()
+	return mock.DeleteContentItemFunc(ctx, contentItemID)
+}
+
+// DeleteContentItemCalls gets all the calls that were made to DeleteContentItem.
+// Check the length with:
+//
+//	len(mockedMongoDB.DeleteContentItemCalls())
+func (mock *MongoDBMock) DeleteContentItemCalls() []struct {
+	Ctx           context.Context
+	ContentItemID string
+} {
+	var calls []struct {
+		Ctx           context.Context
+		ContentItemID string
+	}
+	mock.lockDeleteContentItem.RLock()
+	calls = mock.calls.DeleteContentItem
+	mock.lockDeleteContentItem.RUnlock()
+	return calls
+}
+
 // GetBundle calls GetBundleFunc.
 func (mock *MongoDBMock) GetBundle(ctx context.Context, bundleID string) (*models.Bundle, error) {
 	if mock.GetBundleFunc == nil {
@@ -494,6 +560,46 @@ func (mock *MongoDBMock) GetBundleCalls() []struct {
 	mock.lockGetBundle.RLock()
 	calls = mock.calls.GetBundle
 	mock.lockGetBundle.RUnlock()
+	return calls
+}
+
+// GetContentItemByBundleIDAndContentItemID calls GetContentItemByBundleIDAndContentItemIDFunc.
+func (mock *MongoDBMock) GetContentItemByBundleIDAndContentItemID(ctx context.Context, bundleID string, contentItemID string) (*models.ContentItem, error) {
+	if mock.GetContentItemByBundleIDAndContentItemIDFunc == nil {
+		panic("MongoDBMock.GetContentItemByBundleIDAndContentItemIDFunc: method is nil but MongoDB.GetContentItemByBundleIDAndContentItemID was just called")
+	}
+	callInfo := struct {
+		Ctx           context.Context
+		BundleID      string
+		ContentItemID string
+	}{
+		Ctx:           ctx,
+		BundleID:      bundleID,
+		ContentItemID: contentItemID,
+	}
+	mock.lockGetContentItemByBundleIDAndContentItemID.Lock()
+	mock.calls.GetContentItemByBundleIDAndContentItemID = append(mock.calls.GetContentItemByBundleIDAndContentItemID, callInfo)
+	mock.lockGetContentItemByBundleIDAndContentItemID.Unlock()
+	return mock.GetContentItemByBundleIDAndContentItemIDFunc(ctx, bundleID, contentItemID)
+}
+
+// GetContentItemByBundleIDAndContentItemIDCalls gets all the calls that were made to GetContentItemByBundleIDAndContentItemID.
+// Check the length with:
+//
+//	len(mockedMongoDB.GetContentItemByBundleIDAndContentItemIDCalls())
+func (mock *MongoDBMock) GetContentItemByBundleIDAndContentItemIDCalls() []struct {
+	Ctx           context.Context
+	BundleID      string
+	ContentItemID string
+} {
+	var calls []struct {
+		Ctx           context.Context
+		BundleID      string
+		ContentItemID string
+	}
+	mock.lockGetContentItemByBundleIDAndContentItemID.RLock()
+	calls = mock.calls.GetContentItemByBundleIDAndContentItemID
+	mock.lockGetContentItemByBundleIDAndContentItemID.RUnlock()
 	return calls
 }
 

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -475,7 +475,7 @@ paths:
 responses:
   Conflict:
     description: |
-      Change rejected due to a conflict with the current resource state. A common cause is attempted to change a bundle that is already locked pending publication or has already been published.
+      Change rejected due to a conflict with the current resource state. A common cause is attempting to change a bundle that is already locked pending publication or has already been published.
     schema:
       $ref: "#/definitions/ErrorList"
   ForbiddenError:


### PR DESCRIPTION
### What

[DIS-3322](https://jira.ons.gov.uk/browse/DIS-3322)
Create `DELETE /bundles/{bundle-id}/contents/{content-id}` endpoint

### How to review

https://github.com/ONSdigital/dp-permissions-api/pull/130 - you will need to be on this branch to test this ticket unless the PR is already merged then you'll need to pull the changes

1. Run the `dataset-catalogue` stack using `make up-with-seed` (have the latest dp-compose)
2. Make a DELETE request to `/bundles/bundle-1/contents/f3ee8348-9956-44e1-9c83-55fd2d7b2fb1` without an auth token and 401 should be returned
3. Make the same request again but using the dataset-api service auth token as your authorization and 403 should be returned (both auth errors should not show a response body)
4. Make a DELETE request to `/bundles/bundle-1/contents/f3ee8348-9956-44e1-9c83-55fd2d7b2fb1` with your working auth token and a 204 should be returned. Check the content item in mongo is deleted and an event has also been created
5. In Mongo using `db.getCollection('bundle_contents').find({"bundle_id":"bundle-2"})` change the state of this record to `PUBLISHED`
6. Make a DELETE request to `/bundles/bundle-2/contents/af8b48b0-d085-4ea7-8f12-524fa8e6b0a0` and a 409 should be returned with the error message from acceptance criteria in the ticket above
7. Make a DELETE request but changing the bundleID to one that doesn't exist and a 404 should be returned with an error response. Do the same but with a ContentID that doesn't exist and you should get the same response

Double check that the component tests are checking the same scenarios and all changes are ok

### Who can review

Anyone
