### PR TITLE
add PUT /bundles endpoint

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -58,7 +58,6 @@ func Setup(ctx context.Context, cfg *config.Config, router *mux.Router, store *s
 		"/bundles/{bundle-id}/contents",
 		authMiddleware.Require("bundles:create", api.postBundleContents),
 	)
-
 	api.delete(
 		"/bundles/{bundle-id}/contents/{content-id}",
 		authMiddleware.Require("bundles:delete", api.deleteContentItem),
@@ -67,6 +66,10 @@ func Setup(ctx context.Context, cfg *config.Config, router *mux.Router, store *s
 	// put
 	api.put("/bundles/{bundle-id}/state",
 		authMiddleware.Require("bundles:update", api.putBundleState))
+
+	// put
+	api.put("/bundles/{bundle-id}",
+		authMiddleware.Require("bundles:update", api.putBundle))
 
 	return api
 }
@@ -81,12 +84,12 @@ func (api *BundleAPI) post(path string, handler http.HandlerFunc) {
 	api.Router.HandleFunc(path, handler).Methods(http.MethodPost)
 }
 
-// delete registers a DELETE http.HandlerFunc.
-func (api *BundleAPI) delete(path string, handler http.HandlerFunc) {
-	api.Router.HandleFunc(path, handler).Methods(http.MethodDelete)
-}
-
 // put registers a PUT http.HandlerFunc.
 func (api *BundleAPI) put(path string, handler http.HandlerFunc) {
 	api.Router.HandleFunc(path, handler).Methods(http.MethodPut)
+}
+
+// delete registers a DELETE http.HandlerFunc.
+func (api *BundleAPI) delete(path string, handler http.HandlerFunc) {
+	api.Router.HandleFunc(path, handler).Methods(http.MethodDelete)
 }

--- a/api/bundle_update.go
+++ b/api/bundle_update.go
@@ -90,7 +90,7 @@ func (api *BundleAPI) putBundle(w http.ResponseWriter, r *http.Request) {
 		authHeaders.ServiceToken = r.Header.Get("Authorization")
 	}
 
-	updatedBundle, err := api.stateMachineBundleAPI.UpdateBundleWIP(ctx, bundleID, bundleUpdate, currentBundle, authEntityData, authHeaders)
+	updatedBundle, err := api.stateMachineBundleAPI.PutBundle(ctx, bundleID, bundleUpdate, currentBundle, authEntityData, authHeaders)
 	if err != nil {
 		log.Error(ctx, "putBundle endpoint: bundle update failed", err, logdata)
 		switch err {

--- a/api/bundle_update.go
+++ b/api/bundle_update.go
@@ -3,10 +3,8 @@ package api
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"strings"
-	"time"
 
 	"github.com/ONSdigital/dis-bundle-api/apierrors"
 	"github.com/ONSdigital/dis-bundle-api/models"
@@ -39,9 +37,9 @@ func (api *BundleAPI) putBundle(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	JWTData, err := api.authMiddleware.Parse(strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer "))
+	authEntityData, err := api.GetAuthEntityData(r)
 	if err != nil {
-		api.handleInternalError(ctx, w, r, "failed to parse JWT from authorization header", err, logdata)
+		handleErr(ctx, w, r, err, logdata, RouteNamePutBundle)
 		return
 	}
 
@@ -65,7 +63,7 @@ func (api *BundleAPI) putBundle(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	bundleUpdate, validationErrors, err := api.createAndValidateBundleUpdate(r, bundleID, currentBundle, JWTData.UserID)
+	bundleUpdate, validationErrors, err := api.CreateAndValidateBundleUpdate(r, bundleID, currentBundle, authEntityData.EntityData.UserID)
 	if err != nil {
 		api.handleBadRequestError(ctx, w, r, "bundle creation or validation failed", err, logdata)
 		return
@@ -77,7 +75,7 @@ func (api *BundleAPI) putBundle(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	validationErrs := validateBundleRules(ctx, bundleUpdate, currentBundle, api)
+	validationErrs := api.stateMachineBundleAPI.ValidateBundleRules(ctx, bundleUpdate, currentBundle)
 	if len(validationErrs) > 0 {
 		logdata["validation_errors"] = validationErrs
 		log.Error(ctx, "putBundle endpoint: bundle business rule validation failed", nil, logdata)
@@ -85,80 +83,36 @@ func (api *BundleAPI) putBundle(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	stateChangingToPublished, err := api.handleStateTransition(ctx, bundleUpdate, currentBundle)
+	var authHeaders datasetAPISDK.Headers
+	if r.Header.Get("X-Florence-Token") != "" {
+		authHeaders.ServiceToken = r.Header.Get("X-Florence-Token")
+	} else {
+		authHeaders.ServiceToken = r.Header.Get("Authorization")
+	}
+
+	updatedBundle, err := api.stateMachineBundleAPI.UpdateBundleWIP(ctx, bundleID, bundleUpdate, currentBundle, authEntityData, authHeaders)
 	if err != nil {
-		log.Error(ctx, "putBundle endpoint: invalid state transition", err, logdata)
-		code := models.ErrInvalidParameters
-		errInfo := &models.Error{
-			Code:        &code,
-			Description: apierrors.ErrorDescriptionMalformedRequest,
-			Source:      &models.Source{Field: "/state"},
+		log.Error(ctx, "putBundle endpoint: bundle update failed", err, logdata)
+		switch err {
+		case apierrors.ErrInvalidTransition:
+			code := models.ErrInvalidParameters
+			errInfo := &models.Error{
+				Code:        &code,
+				Description: apierrors.ErrorDescriptionMalformedRequest,
+				Source:      &models.Source{Field: "/state"},
+			}
+			utils.HandleBundleAPIErr(w, r, http.StatusBadRequest, errInfo)
+		case apierrors.ErrNotFound:
+			code := models.NotFound
+			errInfo := &models.Error{
+				Code:        &code,
+				Description: "The requested resource does not exist.",
+				Source:      &models.Source{Field: "/dataset_id"},
+			}
+			utils.HandleBundleAPIErr(w, r, http.StatusNotFound, errInfo)
+		default:
+			api.handleInternalError(ctx, w, r, "bundle update failed", err, logdata)
 		}
-		utils.HandleBundleAPIErr(w, r, http.StatusBadRequest, errInfo)
-		return
-	}
-
-	now := time.Now()
-	bundleUpdate.UpdatedAt = &now
-	bundleUpdate.LastUpdatedBy = &models.User{Email: JWTData.UserID}
-
-	_, err = api.stateMachineBundleAPI.UpdateBundle(ctx, bundleID, bundleUpdate)
-	if err != nil {
-		api.handleInternalError(ctx, w, r, "failed to update bundle in database", err, logdata)
-		return
-	}
-
-	updatedBundle, err := api.stateMachineBundleAPI.UpdateBundleETag(ctx, bundleID, JWTData.UserID)
-	if err != nil {
-		api.handleInternalError(ctx, w, r, "failed to update bundle ETag", err, logdata)
-		return
-	}
-
-	if stateChangingToPublished {
-		var authHeaders datasetAPISDK.Headers
-		if r.Header.Get("X-Florence-Token") != "" {
-			authHeaders.ServiceToken = r.Header.Get("X-Florence-Token")
-		} else {
-			authHeaders.ServiceToken = r.Header.Get("Authorization")
-		}
-
-		err = updateContentItemsWithDatasetInfo(ctx, api, bundleID, authHeaders)
-		if err != nil {
-			log.Error(ctx, "putBundle endpoint: failed to update content items with dataset info", err, logdata)
-		}
-	}
-
-	event := &models.Event{
-		RequestedBy: &models.RequestedBy{
-			ID:    JWTData.UserID,
-			Email: JWTData.UserID,
-		},
-		Action:   models.ActionUpdate,
-		Resource: "/bundles/" + bundleID,
-		Bundle: &models.EventBundle{
-			ID:            updatedBundle.ID,
-			BundleType:    updatedBundle.BundleType,
-			CreatedBy:     updatedBundle.CreatedBy,
-			CreatedAt:     updatedBundle.CreatedAt,
-			LastUpdatedBy: updatedBundle.LastUpdatedBy,
-			PreviewTeams:  updatedBundle.PreviewTeams,
-			ScheduledAt:   updatedBundle.ScheduledAt,
-			State:         updatedBundle.State,
-			Title:         updatedBundle.Title,
-			UpdatedAt:     updatedBundle.UpdatedAt,
-			ManagedBy:     updatedBundle.ManagedBy,
-		},
-	}
-
-	err = models.ValidateEvent(event)
-	if err != nil {
-		api.handleInternalError(ctx, w, r, "event validation failed", err, logdata)
-		return
-	}
-
-	err = api.stateMachineBundleAPI.CreateBundleEvent(ctx, event)
-	if err != nil {
-		api.handleInternalError(ctx, w, r, "failed to create event in database", err, logdata)
 		return
 	}
 
@@ -178,22 +132,6 @@ func (api *BundleAPI) putBundle(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// Helper function to handle state transitions
-func (api *BundleAPI) handleStateTransition(ctx context.Context, bundleUpdate, currentBundle *models.Bundle) (bool, error) {
-	stateChangingToPublished := bundleUpdate.State != "" && currentBundle.State != "" &&
-		bundleUpdate.State == models.BundleStatePublished && currentBundle.State != models.BundleStatePublished
-
-	if bundleUpdate.State != "" && currentBundle.State != "" && bundleUpdate.State != currentBundle.State {
-		err := api.stateMachineBundleAPI.StateMachine.Transition(ctx, api.stateMachineBundleAPI, currentBundle, bundleUpdate)
-		if err != nil {
-			return false, err
-		}
-	}
-
-	return stateChangingToPublished, nil
-}
-
-// Helper function for bad request errors
 func (api *BundleAPI) handleBadRequestError(ctx context.Context, w http.ResponseWriter, r *http.Request, message string, err error, logdata log.Data) {
 	log.Error(ctx, "putBundle endpoint: "+message, err, logdata)
 	code := models.ErrInvalidParameters
@@ -204,8 +142,32 @@ func (api *BundleAPI) handleBadRequestError(ctx context.Context, w http.Response
 	utils.HandleBundleAPIErr(w, r, http.StatusBadRequest, errInfo)
 }
 
+func (api *BundleAPI) handleInternalError(ctx context.Context, w http.ResponseWriter, r *http.Request, message string, err error, logdata log.Data) {
+	log.Error(ctx, "putBundle endpoint: "+message, err, logdata)
+	code := models.InternalError
+	errInfo := &models.Error{
+		Code:        &code,
+		Description: apierrors.ErrorDescriptionInternalError,
+	}
+	utils.HandleBundleAPIErr(w, r, http.StatusInternalServerError, errInfo)
+}
+
+func (api *BundleAPI) handleGetBundleError(ctx context.Context, w http.ResponseWriter, r *http.Request, err error, logdata log.Data) {
+	if err == apierrors.ErrBundleNotFound {
+		log.Error(ctx, "putBundle endpoint: bundle not found", err, logdata)
+		code := models.NotFound
+		errInfo := &models.Error{
+			Code:        &code,
+			Description: apierrors.ErrorDescriptionNotFound,
+		}
+		utils.HandleBundleAPIErr(w, r, http.StatusNotFound, errInfo)
+		return
+	}
+	api.handleInternalError(ctx, w, r, "failed to get bundle", err, logdata)
+}
+
 // Helper function to create and validate bundle update
-func (api *BundleAPI) createAndValidateBundleUpdate(r *http.Request, bundleID string, currentBundle *models.Bundle, email string) (*models.Bundle, []*models.Error, error) {
+func (api BundleAPI) CreateAndValidateBundleUpdate(r *http.Request, bundleID string, currentBundle *models.Bundle, email string) (*models.Bundle, []*models.Error, error) {
 	bundleUpdate, err := models.CreateBundle(r.Body, email)
 	if err != nil {
 		return nil, nil, err
@@ -223,124 +185,4 @@ func (api *BundleAPI) createAndValidateBundleUpdate(r *http.Request, bundleID st
 	}
 
 	return bundleUpdate, nil, nil
-}
-
-func (api *BundleAPI) handleInternalError(ctx context.Context, w http.ResponseWriter, r *http.Request, message string, err error, logdata log.Data) {
-	log.Error(ctx, "putBundle endpoint: "+message, err, logdata)
-	code := models.InternalError
-	errInfo := &models.Error{
-		Code:        &code,
-		Description: apierrors.ErrorDescriptionInternalError,
-	}
-	utils.HandleBundleAPIErr(w, r, http.StatusInternalServerError, errInfo)
-}
-
-// Helper function for GetBundle error handling
-func (api *BundleAPI) handleGetBundleError(ctx context.Context, w http.ResponseWriter, r *http.Request, err error, logdata log.Data) {
-	if err == apierrors.ErrBundleNotFound {
-		log.Error(ctx, "putBundle endpoint: bundle not found", err, logdata)
-		code := models.NotFound
-		errInfo := &models.Error{
-			Code:        &code,
-			Description: apierrors.ErrorDescriptionNotFound,
-		}
-		utils.HandleBundleAPIErr(w, r, http.StatusNotFound, errInfo)
-		return
-	}
-	api.handleInternalError(ctx, w, r, "failed to get bundle", err, logdata)
-}
-
-// validateBundleRules validates the rules for bundle updates
-func validateBundleRules(ctx context.Context, bundleUpdate, currentBundle *models.Bundle, api *BundleAPI) []*models.Error {
-	var validationErrors []*models.Error
-
-	if bundleUpdate.Title != currentBundle.Title {
-		exists, err := api.stateMachineBundleAPI.CheckBundleExistsByTitleUpdate(ctx, bundleUpdate.Title, bundleUpdate.ID)
-		if err != nil {
-			log.Error(ctx, "failed to check bundle title uniqueness", err)
-			code := models.InternalError
-			validationErrors = append(validationErrors, &models.Error{
-				Code:        &code,
-				Description: apierrors.ErrorDescriptionInternalError,
-			})
-			return validationErrors
-		}
-		if exists {
-			code := models.ErrInvalidParameters
-			validationErrors = append(validationErrors, &models.Error{
-				Code:        &code,
-				Description: apierrors.ErrorDescriptionMalformedRequest,
-				Source:      &models.Source{Field: "/title"},
-			})
-		}
-	}
-
-	if bundleUpdate.BundleType == models.BundleTypeScheduled {
-		if bundleUpdate.ScheduledAt == nil {
-			code := models.ErrInvalidParameters
-			validationErrors = append(validationErrors, &models.Error{
-				Code:        &code,
-				Description: apierrors.ErrorDescriptionMalformedRequest,
-				Source:      &models.Source{Field: "/scheduled_at"},
-			})
-		} else if bundleUpdate.ScheduledAt.Before(time.Now()) {
-			code := models.ErrInvalidParameters
-			validationErrors = append(validationErrors, &models.Error{
-				Code:        &code,
-				Description: apierrors.ErrorDescriptionMalformedRequest,
-				Source:      &models.Source{Field: "/scheduled_at"},
-			})
-		}
-	}
-
-	if bundleUpdate.BundleType == models.BundleTypeManual && bundleUpdate.ScheduledAt != nil {
-		code := models.ErrInvalidParameters
-		validationErrors = append(validationErrors, &models.Error{
-			Code:        &code,
-			Description: apierrors.ErrorDescriptionMalformedRequest,
-			Source:      &models.Source{Field: "/scheduled_at"},
-		})
-	}
-
-	return validationErrors
-}
-
-func updateContentItemsWithDatasetInfo(ctx context.Context, api *BundleAPI, bundleID string, authHeaders datasetAPISDK.Headers) error {
-	contentItems, err := api.stateMachineBundleAPI.GetContentItemsByBundleID(ctx, bundleID)
-	if err != nil {
-		log.Error(ctx, "failed to get content items", err, log.Data{"bundle_id": bundleID})
-		return err
-	}
-
-	if len(contentItems) == 0 {
-		log.Info(ctx, "no content items found for bundle", log.Data{"bundle_id": bundleID})
-		return nil
-	}
-
-	for _, contentItem := range contentItems {
-		log.Info(ctx, "calling dataset API client", log.Data{
-			"dataset_id":                 contentItem.Metadata.DatasetID,
-			"auth_headers_service_token": authHeaders.ServiceToken != "",
-			"client_debug":               fmt.Sprintf("%+v", api.stateMachineBundleAPI.DatasetAPIClient),
-		})
-
-		dataset, err := api.stateMachineBundleAPI.DatasetAPIClient.GetDataset(ctx, authHeaders, "", contentItem.Metadata.DatasetID)
-		if err != nil {
-			log.Error(ctx, "dataset api client call failed", err, log.Data{
-				"content_item_id": contentItem.ID,
-				"dataset_id":      contentItem.Metadata.DatasetID,
-			})
-			continue
-		}
-
-		err = api.stateMachineBundleAPI.UpdateContentItemDatasetInfo(ctx, contentItem.ID, dataset.Title, dataset.State)
-		if err != nil {
-			log.Error(ctx, "update content item failed", err, log.Data{
-				"content_item_id": contentItem.ID,
-				"dataset_id":      contentItem.Metadata.DatasetID,
-			})
-			continue
-		}
-	}
-	return nil
 }

--- a/api/bundle_update.go
+++ b/api/bundle_update.go
@@ -1,0 +1,346 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/ONSdigital/dis-bundle-api/apierrors"
+	"github.com/ONSdigital/dis-bundle-api/models"
+	"github.com/ONSdigital/dis-bundle-api/utils"
+	datasetAPISDK "github.com/ONSdigital/dp-dataset-api/sdk"
+	dpresponse "github.com/ONSdigital/dp-net/v3/handlers/response"
+	dphttp "github.com/ONSdigital/dp-net/v3/http"
+	"github.com/ONSdigital/log.go/v2/log"
+	"github.com/gorilla/mux"
+)
+
+func (api *BundleAPI) putBundle(w http.ResponseWriter, r *http.Request) {
+	defer dphttp.DrainBody(r)
+
+	ctx := r.Context()
+	vars := mux.Vars(r)
+	bundleID := vars["bundle-id"]
+
+	logdata := log.Data{"bundle_id": bundleID}
+
+	ifMatchHeader := r.Header.Get("If-Match")
+	if ifMatchHeader == "" {
+		log.Error(ctx, "putBundle endpoint: missing If-Match header", nil, logdata)
+		code := models.CodeConflict
+		errInfo := &models.Error{
+			Code:        &code,
+			Description: "Change rejected due to a conflict with the current resource state. A common cause is attempted to change a bundle that is already locked pending publication or has already been published.",
+		}
+		utils.HandleBundleAPIErr(w, r, http.StatusConflict, errInfo)
+		return
+	}
+
+	JWTData, err := api.authMiddleware.Parse(strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer "))
+	if err != nil {
+		api.handleInternalError(ctx, w, r, "failed to parse JWT from authorization header", err, logdata)
+		return
+	}
+
+	currentBundle, err := api.stateMachineBundleAPI.GetBundle(ctx, bundleID)
+	if err != nil {
+		api.handleGetBundleError(ctx, w, r, err, logdata)
+		return
+	}
+
+	trimmedIfMatch := strings.Trim(ifMatchHeader, "\"")
+	trimmedDBETag := strings.Trim(currentBundle.ETag, "\"")
+
+	if trimmedDBETag != trimmedIfMatch {
+		log.Error(ctx, "putBundle endpoint: ETag mismatch", nil, logdata)
+		code := models.CodeConflict
+		errInfo := &models.Error{
+			Code:        &code,
+			Description: "Change rejected due to a conflict with the current resource state. A common cause is attempted to change a bundle that is already locked pending publication or has already been published.",
+		}
+		utils.HandleBundleAPIErr(w, r, http.StatusConflict, errInfo)
+		return
+	}
+
+	bundleUpdate, validationErrors, err := api.createAndValidateBundleUpdate(r, bundleID, currentBundle, JWTData.UserID)
+	if err != nil {
+		api.handleBadRequestError(ctx, w, r, "bundle creation or validation failed", err, logdata)
+		return
+	}
+	if len(validationErrors) > 0 {
+		logdata["validation_errors"] = validationErrors
+		log.Error(ctx, "putBundle endpoint: bundle validation failed", nil, logdata)
+		utils.HandleBundleAPIErr(w, r, http.StatusBadRequest, validationErrors...)
+		return
+	}
+
+	validationErrs := validateBundleRules(ctx, bundleUpdate, currentBundle, api)
+	if len(validationErrs) > 0 {
+		logdata["validation_errors"] = validationErrs
+		log.Error(ctx, "putBundle endpoint: bundle business rule validation failed", nil, logdata)
+		utils.HandleBundleAPIErr(w, r, http.StatusBadRequest, validationErrs...)
+		return
+	}
+
+	stateChangingToPublished, err := api.handleStateTransition(ctx, bundleUpdate, currentBundle)
+	if err != nil {
+		log.Error(ctx, "putBundle endpoint: invalid state transition", err, logdata)
+		code := models.ErrInvalidParameters
+		errInfo := &models.Error{
+			Code:        &code,
+			Description: apierrors.ErrorDescriptionMalformedRequest,
+			Source:      &models.Source{Field: "/state"},
+		}
+		utils.HandleBundleAPIErr(w, r, http.StatusBadRequest, errInfo)
+		return
+	}
+
+	now := time.Now()
+	bundleUpdate.UpdatedAt = &now
+	bundleUpdate.LastUpdatedBy = &models.User{Email: JWTData.UserID}
+
+	_, err = api.stateMachineBundleAPI.UpdateBundle(ctx, bundleID, bundleUpdate)
+	if err != nil {
+		api.handleInternalError(ctx, w, r, "failed to update bundle in database", err, logdata)
+		return
+	}
+
+	updatedBundle, err := api.stateMachineBundleAPI.UpdateBundleETag(ctx, bundleID, JWTData.UserID)
+	if err != nil {
+		api.handleInternalError(ctx, w, r, "failed to update bundle ETag", err, logdata)
+		return
+	}
+
+	if stateChangingToPublished {
+		var authHeaders datasetAPISDK.Headers
+		if r.Header.Get("X-Florence-Token") != "" {
+			authHeaders.ServiceToken = r.Header.Get("X-Florence-Token")
+		} else {
+			authHeaders.ServiceToken = r.Header.Get("Authorization")
+		}
+
+		err = updateContentItemsWithDatasetInfo(ctx, api, bundleID, authHeaders)
+		if err != nil {
+			log.Error(ctx, "putBundle endpoint: failed to update content items with dataset info", err, logdata)
+		}
+	}
+
+	event := &models.Event{
+		RequestedBy: &models.RequestedBy{
+			ID:    JWTData.UserID,
+			Email: JWTData.UserID,
+		},
+		Action:   models.ActionUpdate,
+		Resource: "/bundles/" + bundleID,
+		Bundle: &models.EventBundle{
+			ID:            updatedBundle.ID,
+			BundleType:    updatedBundle.BundleType,
+			CreatedBy:     updatedBundle.CreatedBy,
+			CreatedAt:     updatedBundle.CreatedAt,
+			LastUpdatedBy: updatedBundle.LastUpdatedBy,
+			PreviewTeams:  updatedBundle.PreviewTeams,
+			ScheduledAt:   updatedBundle.ScheduledAt,
+			State:         updatedBundle.State,
+			Title:         updatedBundle.Title,
+			UpdatedAt:     updatedBundle.UpdatedAt,
+			ManagedBy:     updatedBundle.ManagedBy,
+		},
+	}
+
+	err = models.ValidateEvent(event)
+	if err != nil {
+		api.handleInternalError(ctx, w, r, "event validation failed", err, logdata)
+		return
+	}
+
+	err = api.stateMachineBundleAPI.CreateBundleEvent(ctx, event)
+	if err != nil {
+		api.handleInternalError(ctx, w, r, "failed to create event in database", err, logdata)
+		return
+	}
+
+	bundleJSON, err := json.Marshal(updatedBundle)
+	if err != nil {
+		api.handleInternalError(ctx, w, r, "failed to marshal bundle to JSON", err, logdata)
+		return
+	}
+
+	dpresponse.SetETag(w, updatedBundle.ETag)
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+
+	if _, err := w.Write(bundleJSON); err != nil {
+		log.Error(ctx, "putBundle endpoint: error writing response body", err, logdata)
+	}
+}
+
+// Helper function to handle state transitions
+func (api *BundleAPI) handleStateTransition(ctx context.Context, bundleUpdate, currentBundle *models.Bundle) (bool, error) {
+	stateChangingToPublished := bundleUpdate.State != "" && currentBundle.State != "" &&
+		bundleUpdate.State == models.BundleStatePublished && currentBundle.State != models.BundleStatePublished
+
+	if bundleUpdate.State != "" && currentBundle.State != "" && bundleUpdate.State != currentBundle.State {
+		err := api.stateMachineBundleAPI.StateMachine.Transition(ctx, api.stateMachineBundleAPI, currentBundle, bundleUpdate)
+		if err != nil {
+			return false, err
+		}
+	}
+
+	return stateChangingToPublished, nil
+}
+
+// Helper function for bad request errors
+func (api *BundleAPI) handleBadRequestError(ctx context.Context, w http.ResponseWriter, r *http.Request, message string, err error, logdata log.Data) {
+	log.Error(ctx, "putBundle endpoint: "+message, err, logdata)
+	code := models.ErrInvalidParameters
+	errInfo := &models.Error{
+		Code:        &code,
+		Description: apierrors.ErrorDescriptionMalformedRequest,
+	}
+	utils.HandleBundleAPIErr(w, r, http.StatusBadRequest, errInfo)
+}
+
+// Helper function to create and validate bundle update
+func (api *BundleAPI) createAndValidateBundleUpdate(r *http.Request, bundleID string, currentBundle *models.Bundle, email string) (*models.Bundle, []*models.Error, error) {
+	bundleUpdate, err := models.CreateBundle(r.Body, email)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	bundleUpdate.ID = bundleID
+	bundleUpdate.CreatedAt = currentBundle.CreatedAt
+	bundleUpdate.CreatedBy = currentBundle.CreatedBy
+
+	models.CleanBundle(bundleUpdate)
+
+	validationErrors := models.ValidateBundle(bundleUpdate)
+	if len(validationErrors) > 0 {
+		return nil, validationErrors, nil
+	}
+
+	return bundleUpdate, nil, nil
+}
+
+func (api *BundleAPI) handleInternalError(ctx context.Context, w http.ResponseWriter, r *http.Request, message string, err error, logdata log.Data) {
+	log.Error(ctx, "putBundle endpoint: "+message, err, logdata)
+	code := models.InternalError
+	errInfo := &models.Error{
+		Code:        &code,
+		Description: apierrors.ErrorDescriptionInternalError,
+	}
+	utils.HandleBundleAPIErr(w, r, http.StatusInternalServerError, errInfo)
+}
+
+// Helper function for GetBundle error handling
+func (api *BundleAPI) handleGetBundleError(ctx context.Context, w http.ResponseWriter, r *http.Request, err error, logdata log.Data) {
+	if err == apierrors.ErrBundleNotFound {
+		log.Error(ctx, "putBundle endpoint: bundle not found", err, logdata)
+		code := models.NotFound
+		errInfo := &models.Error{
+			Code:        &code,
+			Description: apierrors.ErrorDescriptionNotFound,
+		}
+		utils.HandleBundleAPIErr(w, r, http.StatusNotFound, errInfo)
+		return
+	}
+	api.handleInternalError(ctx, w, r, "failed to get bundle", err, logdata)
+}
+
+// validateBundleRules validates the rules for bundle updates
+func validateBundleRules(ctx context.Context, bundleUpdate, currentBundle *models.Bundle, api *BundleAPI) []*models.Error {
+	var validationErrors []*models.Error
+
+	if bundleUpdate.Title != currentBundle.Title {
+		exists, err := api.stateMachineBundleAPI.CheckBundleExistsByTitleUpdate(ctx, bundleUpdate.Title, bundleUpdate.ID)
+		if err != nil {
+			log.Error(ctx, "failed to check bundle title uniqueness", err)
+			code := models.InternalError
+			validationErrors = append(validationErrors, &models.Error{
+				Code:        &code,
+				Description: apierrors.ErrorDescriptionInternalError,
+			})
+			return validationErrors
+		}
+		if exists {
+			code := models.ErrInvalidParameters
+			validationErrors = append(validationErrors, &models.Error{
+				Code:        &code,
+				Description: apierrors.ErrorDescriptionMalformedRequest,
+				Source:      &models.Source{Field: "/title"},
+			})
+		}
+	}
+
+	if bundleUpdate.BundleType == models.BundleTypeScheduled {
+		if bundleUpdate.ScheduledAt == nil {
+			code := models.ErrInvalidParameters
+			validationErrors = append(validationErrors, &models.Error{
+				Code:        &code,
+				Description: apierrors.ErrorDescriptionMalformedRequest,
+				Source:      &models.Source{Field: "/scheduled_at"},
+			})
+		} else if bundleUpdate.ScheduledAt.Before(time.Now()) {
+			code := models.ErrInvalidParameters
+			validationErrors = append(validationErrors, &models.Error{
+				Code:        &code,
+				Description: apierrors.ErrorDescriptionMalformedRequest,
+				Source:      &models.Source{Field: "/scheduled_at"},
+			})
+		}
+	}
+
+	if bundleUpdate.BundleType == models.BundleTypeManual && bundleUpdate.ScheduledAt != nil {
+		code := models.ErrInvalidParameters
+		validationErrors = append(validationErrors, &models.Error{
+			Code:        &code,
+			Description: apierrors.ErrorDescriptionMalformedRequest,
+			Source:      &models.Source{Field: "/scheduled_at"},
+		})
+	}
+
+	return validationErrors
+}
+
+func updateContentItemsWithDatasetInfo(ctx context.Context, api *BundleAPI, bundleID string, authHeaders datasetAPISDK.Headers) error {
+	contentItems, err := api.stateMachineBundleAPI.GetContentItemsByBundleID(ctx, bundleID)
+	if err != nil {
+		log.Error(ctx, "failed to get content items", err, log.Data{"bundle_id": bundleID})
+		return err
+	}
+
+	if len(contentItems) == 0 {
+		log.Info(ctx, "no content items found for bundle", log.Data{"bundle_id": bundleID})
+		return nil
+	}
+
+	for _, contentItem := range contentItems {
+		log.Info(ctx, "calling dataset API client", log.Data{
+			"dataset_id":                 contentItem.Metadata.DatasetID,
+			"auth_headers_service_token": authHeaders.ServiceToken != "",
+			"client_debug":               fmt.Sprintf("%+v", api.stateMachineBundleAPI.DatasetAPIClient),
+		})
+
+		dataset, err := api.stateMachineBundleAPI.DatasetAPIClient.GetDataset(ctx, authHeaders, "", contentItem.Metadata.DatasetID)
+		if err != nil {
+			log.Error(ctx, "dataset api client call failed", err, log.Data{
+				"content_item_id": contentItem.ID,
+				"dataset_id":      contentItem.Metadata.DatasetID,
+			})
+			continue
+		}
+
+		err = api.stateMachineBundleAPI.UpdateContentItemDatasetInfo(ctx, contentItem.ID, dataset.Title, dataset.State)
+		if err != nil {
+			log.Error(ctx, "update content item failed", err, log.Data{
+				"content_item_id": contentItem.ID,
+				"dataset_id":      contentItem.Metadata.DatasetID,
+			})
+			continue
+		}
+	}
+	return nil
+}

--- a/api/bundle_update_test.go
+++ b/api/bundle_update_test.go
@@ -1,0 +1,833 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/ONSdigital/dis-bundle-api/apierrors"
+	"github.com/ONSdigital/dis-bundle-api/models"
+	"github.com/ONSdigital/dis-bundle-api/store"
+	storetest "github.com/ONSdigital/dis-bundle-api/store/datastoretest"
+	datasetAPIModels "github.com/ONSdigital/dp-dataset-api/models"
+	datasetAPISDK "github.com/ONSdigital/dp-dataset-api/sdk"
+	datasetAPISDKMock "github.com/ONSdigital/dp-dataset-api/sdk/mocks"
+	"github.com/gorilla/mux"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+const (
+	bundle1  = "bundle-1"
+	dataset1 = "dataset-1"
+	title1   = "title1"
+	newEtag  = "new-etag"
+	content1 = "content1"
+)
+
+func TestPutBundle_Success(t *testing.T) {
+	t.Parallel()
+
+	Convey("Given a valid PUT request to /bundles/{bundle-id}", t, func() {
+		now := time.Now().UTC()
+		existingBundle := &models.Bundle{
+			ID:           bundle1,
+			Title:        "Original Title",
+			BundleType:   models.BundleTypeManual,
+			ETag:         "original-etag",
+			State:        models.BundleStateDraft,
+			CreatedAt:    &now,
+			CreatedBy:    &models.User{Email: "creator@example.com"},
+			UpdatedAt:    &now,
+			ManagedBy:    models.ManagedByDataAdmin,
+			PreviewTeams: []models.PreviewTeam{{ID: "team-1"}},
+		}
+
+		updateRequest := &models.Bundle{
+			Title:        title1,
+			BundleType:   models.BundleTypeManual,
+			State:        models.BundleStateDraft,
+			ManagedBy:    models.ManagedByDataAdmin,
+			PreviewTeams: []models.PreviewTeam{{ID: "team-1"}},
+		}
+
+		updateRequestJSON, err := json.Marshal(updateRequest)
+		So(err, ShouldBeNil)
+
+		mockedDatastore := &storetest.StorerMock{
+			GetBundleFunc: func(ctx context.Context, id string) (*models.Bundle, error) {
+				if id == bundle1 {
+					return existingBundle, nil
+				}
+				return nil, apierrors.ErrBundleNotFound
+			},
+			CheckBundleExistsByTitleUpdateFunc: func(ctx context.Context, title, excludeID string) (bool, error) {
+				if title == title1 && excludeID == bundle1 {
+					return false, nil
+				}
+				return false, nil
+			},
+			UpdateBundleFunc: func(ctx context.Context, bundleID string, bundle *models.Bundle) (*models.Bundle, error) {
+				if bundleID == bundle1 {
+					bundle.ID = bundleID
+					return bundle, nil
+				}
+				return nil, errors.New("failed to update bundle")
+			},
+			UpdateBundleETagFunc: func(ctx context.Context, bundleID, email string) (*models.Bundle, error) {
+				if bundleID == bundle1 {
+					updatedBundle := *existingBundle
+					updatedBundle.Title = title1
+					updatedBundle.ETag = newEtag
+					return &updatedBundle, nil
+				}
+				return nil, errors.New("failed to update ETag")
+			},
+			CreateBundleEventFunc: func(ctx context.Context, event *models.Event) error {
+				if event.Action == models.ActionUpdate && event.Resource == "/bundles/bundle-1" {
+					return nil
+				}
+				return errors.New("failed to create event")
+			},
+		}
+
+		bundleAPI := GetBundleAPIWithMocks(store.Datastore{Backend: mockedDatastore}, &datasetAPISDKMock.ClienterMock{}, false)
+
+		Convey("When putBundle is called with valid data", func() {
+			r := httptest.NewRequest("PUT", "/bundles/bundle-1", bytes.NewReader(updateRequestJSON))
+			r = mux.SetURLVars(r, map[string]string{"bundle-id": bundle1})
+			r.Header.Set("If-Match", "original-etag")
+			r.Header.Set("Authorization", "Bearer test-auth-token")
+			w := httptest.NewRecorder()
+
+			bundleAPI.putBundle(w, r)
+
+			Convey("Then it should return 200 OK with updated bundle", func() {
+				So(w.Code, ShouldEqual, http.StatusOK)
+				So(w.Header().Get("Content-Type"), ShouldEqual, "application/json")
+				So(w.Header().Get("Cache-Control"), ShouldEqual, "no-store")
+				So(w.Header().Get("ETag"), ShouldEqual, newEtag)
+
+				var response models.Bundle
+				err := json.NewDecoder(w.Body).Decode(&response)
+				So(err, ShouldBeNil)
+				So(response.ID, ShouldEqual, bundle1)
+				So(response.Title, ShouldEqual, title1)
+			})
+		})
+	})
+}
+
+func TestPutBundle_StateTransition_Success(t *testing.T) {
+	t.Parallel()
+
+	Convey("Given a PUT request with valid state transition", t, func() {
+		now := time.Now().UTC()
+		existingBundle := &models.Bundle{
+			ID:           bundle1,
+			Title:        "Test Bundle",
+			BundleType:   models.BundleTypeManual,
+			ETag:         "original-etag",
+			State:        models.BundleStateDraft,
+			CreatedAt:    &now,
+			CreatedBy:    &models.User{Email: "creator@example.com"},
+			UpdatedAt:    &now,
+			ManagedBy:    models.ManagedByDataAdmin,
+			PreviewTeams: []models.PreviewTeam{{ID: "team-1"}},
+		}
+
+		updateRequest := &models.Bundle{
+			Title:        "Test Bundle",
+			BundleType:   models.BundleTypeManual,
+			State:        models.BundleStateInReview,
+			ManagedBy:    models.ManagedByDataAdmin,
+			PreviewTeams: []models.PreviewTeam{{ID: "team-1"}},
+		}
+
+		updateRequestJSON, err := json.Marshal(updateRequest)
+		So(err, ShouldBeNil)
+
+		mockedDatastore := &storetest.StorerMock{
+			GetBundleFunc: func(ctx context.Context, id string) (*models.Bundle, error) {
+				return existingBundle, nil
+			},
+			CheckBundleExistsByTitleUpdateFunc: func(ctx context.Context, title, excludeID string) (bool, error) {
+				return false, nil
+			},
+			UpdateBundleFunc: func(ctx context.Context, bundleID string, bundle *models.Bundle) (*models.Bundle, error) {
+				return bundle, nil
+			},
+			UpdateBundleETagFunc: func(ctx context.Context, bundleID, email string) (*models.Bundle, error) {
+				updatedBundle := *existingBundle
+				updatedBundle.State = models.BundleStateInReview
+				updatedBundle.ETag = newEtag
+				return &updatedBundle, nil
+			},
+			CreateBundleEventFunc: func(ctx context.Context, event *models.Event) error {
+				return nil
+			},
+		}
+
+		bundleAPI := GetBundleAPIWithMocks(store.Datastore{Backend: mockedDatastore}, &datasetAPISDKMock.ClienterMock{}, false)
+
+		Convey("When putBundle is called with valid state transition", func() {
+			r := httptest.NewRequest("PUT", "/bundles/bundle-1", bytes.NewReader(updateRequestJSON))
+			r = mux.SetURLVars(r, map[string]string{"bundle-id": bundle1})
+			r.Header.Set("If-Match", "original-etag")
+			r.Header.Set("Authorization", "Bearer test-auth-token")
+			w := httptest.NewRecorder()
+
+			bundleAPI.putBundle(w, r)
+
+			Convey("Then it should return 200 OK with updated state", func() {
+				So(w.Code, ShouldEqual, http.StatusOK)
+
+				var response models.Bundle
+				err := json.NewDecoder(w.Body).Decode(&response)
+				So(err, ShouldBeNil)
+				So(response.State, ShouldEqual, models.BundleStateInReview)
+			})
+		})
+	})
+}
+
+func TestPutBundle_StateTransitionToPublished_UpdatesContentItems(t *testing.T) {
+	t.Parallel()
+
+	Convey("Given a PUT request transitioning to PUBLISHED state", t, func() {
+		now := time.Now().UTC()
+		existingBundle := &models.Bundle{
+			ID:           bundle1,
+			Title:        "Test Bundle",
+			BundleType:   models.BundleTypeManual,
+			ETag:         "original-etag",
+			State:        models.BundleStateApproved,
+			CreatedAt:    &now,
+			CreatedBy:    &models.User{Email: "creator@example.com"},
+			UpdatedAt:    &now,
+			ManagedBy:    models.ManagedByDataAdmin,
+			PreviewTeams: []models.PreviewTeam{{ID: "team-1"}},
+		}
+
+		updateRequest := &models.Bundle{
+			Title:        "Test Bundle",
+			BundleType:   models.BundleTypeManual,
+			State:        models.BundleStatePublished,
+			ManagedBy:    models.ManagedByDataAdmin,
+			PreviewTeams: []models.PreviewTeam{{ID: "team-1"}},
+		}
+
+		updateRequestJSON, err := json.Marshal(updateRequest)
+		So(err, ShouldBeNil)
+
+		contentItems := []*models.ContentItem{
+			{
+				ID:       content1,
+				BundleID: bundle1,
+				Metadata: models.Metadata{
+					DatasetID: dataset1,
+					Title:     "Old Title",
+				},
+				State: ptrState(models.StateApproved),
+			},
+		}
+
+		mockedDatastore := &storetest.StorerMock{
+			GetBundleFunc: func(ctx context.Context, id string) (*models.Bundle, error) {
+				return existingBundle, nil
+			},
+			CheckBundleExistsByTitleUpdateFunc: func(ctx context.Context, title, excludeID string) (bool, error) {
+				return false, nil
+			},
+			UpdateBundleFunc: func(ctx context.Context, bundleID string, bundle *models.Bundle) (*models.Bundle, error) {
+				return bundle, nil
+			},
+			UpdateBundleETagFunc: func(ctx context.Context, bundleID, email string) (*models.Bundle, error) {
+				updatedBundle := *existingBundle
+				updatedBundle.State = models.BundleStatePublished
+				updatedBundle.ETag = newEtag
+				return &updatedBundle, nil
+			},
+			CreateBundleEventFunc: func(ctx context.Context, event *models.Event) error {
+				return nil
+			},
+			GetContentItemsByBundleIDFunc: func(ctx context.Context, bundleID string) ([]*models.ContentItem, error) {
+				if bundleID == bundle1 {
+					return contentItems, nil
+				}
+				return nil, errors.New("bundle not found")
+			},
+			UpdateContentItemDatasetInfoFunc: func(ctx context.Context, contentItemID, title, state string) error {
+				if contentItemID == content1 && title == "Dataset Title" && state == "published" {
+					return nil
+				}
+				return errors.New("failed to update content item")
+			},
+		}
+
+		mockDatasetAPIClient := &datasetAPISDKMock.ClienterMock{
+			GetDatasetFunc: func(ctx context.Context, headers datasetAPISDK.Headers, collectionID, datasetID string) (datasetAPIModels.Dataset, error) {
+				if datasetID == dataset1 {
+					return datasetAPIModels.Dataset{
+						ID:    datasetID,
+						Title: "Dataset Title",
+						State: "published",
+					}, nil
+				}
+				return datasetAPIModels.Dataset{}, errors.New("dataset not found")
+			},
+		}
+
+		bundleAPI := GetBundleAPIWithMocks(store.Datastore{Backend: mockedDatastore}, &datasetAPISDKMock.ClienterMock{}, false)
+		bundleAPI.stateMachineBundleAPI.DatasetAPIClient = mockDatasetAPIClient
+
+		Convey("When putBundle is called with transition to PUBLISHED", func() {
+			r := httptest.NewRequest("PUT", "/bundles/bundle-1", bytes.NewReader(updateRequestJSON))
+			r = mux.SetURLVars(r, map[string]string{"bundle-id": bundle1})
+			r.Header.Set("If-Match", "original-etag")
+			r.Header.Set("Authorization", "Bearer test-auth-token")
+			w := httptest.NewRecorder()
+
+			bundleAPI.putBundle(w, r)
+
+			Convey("Then it should return 200 OK and update content items", func() {
+				So(w.Code, ShouldEqual, http.StatusOK)
+
+				var response models.Bundle
+				err := json.NewDecoder(w.Body).Decode(&response)
+				So(err, ShouldBeNil)
+				So(response.State, ShouldEqual, models.BundleStatePublished)
+
+				So(len(mockedDatastore.GetContentItemsByBundleIDCalls()), ShouldEqual, 1)
+				So(mockedDatastore.GetContentItemsByBundleIDCalls()[0].BundleID, ShouldEqual, bundle1)
+
+				So(len(mockedDatastore.UpdateContentItemDatasetInfoCalls()), ShouldEqual, 1)
+				So(mockedDatastore.UpdateContentItemDatasetInfoCalls()[0].ContentItemID, ShouldEqual, content1)
+				So(mockedDatastore.UpdateContentItemDatasetInfoCalls()[0].Title, ShouldEqual, "Dataset Title")
+				So(mockedDatastore.UpdateContentItemDatasetInfoCalls()[0].State, ShouldEqual, "published")
+			})
+		})
+	})
+}
+
+func TestPutBundle_MissingIfMatchHeader_Failure(t *testing.T) {
+	t.Parallel()
+
+	Convey("Given a PUT request without If-Match header", t, func() {
+		updateRequest := &models.Bundle{
+			Title:      "title-2",
+			BundleType: models.BundleTypeManual,
+			State:      models.BundleStateDraft,
+			ManagedBy:  models.ManagedByDataAdmin,
+		}
+
+		updateRequestJSON, err := json.Marshal(updateRequest)
+		So(err, ShouldBeNil)
+
+		bundleAPI := GetBundleAPIWithMocks(store.Datastore{Backend: &storetest.StorerMock{}}, &datasetAPISDKMock.ClienterMock{}, false)
+
+		Convey("When putBundle is called", func() {
+			r := httptest.NewRequest("PUT", "/bundles/bundle-1", bytes.NewReader(updateRequestJSON))
+			r = mux.SetURLVars(r, map[string]string{"bundle-id": bundle1})
+			r.Header.Set("Authorization", "Bearer test-auth-token")
+			w := httptest.NewRecorder()
+
+			bundleAPI.putBundle(w, r)
+
+			Convey("Then it should return 409 Conflict", func() {
+				So(w.Code, ShouldEqual, http.StatusConflict)
+
+				var errResp models.ErrorList
+				err := json.NewDecoder(w.Body).Decode(&errResp)
+				So(err, ShouldBeNil)
+
+				codeConflict := models.CodeConflict
+				expectedErrResp := models.ErrorList{
+					Errors: []*models.Error{
+						{
+							Code:        &codeConflict,
+							Description: "Change rejected due to a conflict with the current resource state. A common cause is attempted to change a bundle that is already locked pending publication or has already been published.",
+						},
+					},
+				}
+				So(errResp, ShouldResemble, expectedErrResp)
+			})
+		})
+	})
+}
+
+func TestPutBundle_ETagMismatch_Failure(t *testing.T) {
+	t.Parallel()
+
+	Convey("Given a PUT request with mismatched ETag", t, func() {
+		now := time.Now().UTC()
+		existingBundle := &models.Bundle{
+			ID:        bundle1,
+			Title:     "Original Title",
+			ETag:      "correct-etag",
+			CreatedAt: &now,
+			CreatedBy: &models.User{Email: "creator@example.com"},
+		}
+
+		updateRequest := &models.Bundle{
+			Title:      "title-3",
+			BundleType: models.BundleTypeManual,
+			State:      models.BundleStateDraft,
+			ManagedBy:  models.ManagedByDataAdmin,
+		}
+
+		updateRequestJSON, err := json.Marshal(updateRequest)
+		So(err, ShouldBeNil)
+
+		mockedDatastore := &storetest.StorerMock{
+			GetBundleFunc: func(ctx context.Context, id string) (*models.Bundle, error) {
+				return existingBundle, nil
+			},
+		}
+
+		bundleAPI := GetBundleAPIWithMocks(store.Datastore{Backend: mockedDatastore}, &datasetAPISDKMock.ClienterMock{}, false)
+
+		Convey("When putBundle is called with wrong ETag", func() {
+			r := httptest.NewRequest("PUT", "/bundles/bundle-1", bytes.NewReader(updateRequestJSON))
+			r = mux.SetURLVars(r, map[string]string{"bundle-id": bundle1})
+			r.Header.Set("If-Match", "wrong-etag")
+			r.Header.Set("Authorization", "Bearer test-auth-token")
+			w := httptest.NewRecorder()
+
+			bundleAPI.putBundle(w, r)
+
+			Convey("Then it should return 409 Conflict", func() {
+				So(w.Code, ShouldEqual, http.StatusConflict)
+
+				var errResp models.ErrorList
+				err := json.NewDecoder(w.Body).Decode(&errResp)
+				So(err, ShouldBeNil)
+
+				codeConflict := models.CodeConflict
+				expectedErrResp := models.ErrorList{
+					Errors: []*models.Error{
+						{
+							Code:        &codeConflict,
+							Description: "Change rejected due to a conflict with the current resource state. A common cause is attempted to change a bundle that is already locked pending publication or has already been published.",
+						},
+					},
+				}
+				So(errResp, ShouldResemble, expectedErrResp)
+			})
+		})
+	})
+}
+
+func TestPutBundle_MalformedJSON_Failure(t *testing.T) {
+	t.Parallel()
+
+	Convey("Given a PUT request with malformed JSON", t, func() {
+		now := time.Now().UTC()
+		existingBundle := &models.Bundle{
+			ID:        bundle1,
+			ETag:      "original-etag",
+			State:     models.BundleStateDraft,
+			CreatedAt: &now,
+			CreatedBy: &models.User{Email: "creator@example.com"},
+		}
+
+		mockedDatastore := &storetest.StorerMock{
+			GetBundleFunc: func(ctx context.Context, id string) (*models.Bundle, error) {
+				return existingBundle, nil
+			},
+		}
+
+		bundleAPI := GetBundleAPIWithMocks(store.Datastore{Backend: mockedDatastore}, &datasetAPISDKMock.ClienterMock{}, false)
+
+		Convey("When putBundle is called with invalid JSON", func() {
+			r := httptest.NewRequest("PUT", "/bundles/bundle-1", bytes.NewReader([]byte("invalid json")))
+			r = mux.SetURLVars(r, map[string]string{"bundle-id": bundle1})
+			r.Header.Set("If-Match", "original-etag")
+			r.Header.Set("Authorization", "Bearer test-auth-token")
+			w := httptest.NewRecorder()
+
+			bundleAPI.putBundle(w, r)
+
+			Convey("Then it should return 400 Bad Request", func() {
+				So(w.Code, ShouldEqual, http.StatusBadRequest)
+
+				var errResp models.ErrorList
+				err := json.NewDecoder(w.Body).Decode(&errResp)
+				So(err, ShouldBeNil)
+
+				codeBadRequest := models.ErrInvalidParameters
+				expectedErrResp := models.ErrorList{
+					Errors: []*models.Error{
+						{
+							Code:        &codeBadRequest,
+							Description: apierrors.ErrorDescriptionMalformedRequest,
+						},
+					},
+				}
+				So(errResp, ShouldResemble, expectedErrResp)
+			})
+		})
+	})
+}
+
+func TestPutBundle_DuplicateTitle_Failure(t *testing.T) {
+	t.Parallel()
+
+	Convey("Given a PUT request with duplicate title", t, func() {
+		now := time.Now().UTC()
+		existingBundle := &models.Bundle{
+			ID:        bundle1,
+			Title:     "Original Title",
+			ETag:      "original-etag",
+			CreatedAt: &now,
+			CreatedBy: &models.User{Email: "creator@example.com"},
+		}
+
+		updateRequest := &models.Bundle{
+			Title:        "Existing Title",
+			BundleType:   models.BundleTypeManual,
+			State:        models.BundleStateDraft,
+			ManagedBy:    models.ManagedByDataAdmin,
+			PreviewTeams: []models.PreviewTeam{{ID: "team-1"}},
+		}
+
+		updateRequestJSON, err := json.Marshal(updateRequest)
+		So(err, ShouldBeNil)
+
+		mockedDatastore := &storetest.StorerMock{
+			GetBundleFunc: func(ctx context.Context, id string) (*models.Bundle, error) {
+				return existingBundle, nil
+			},
+			CheckBundleExistsByTitleUpdateFunc: func(ctx context.Context, title, excludeID string) (bool, error) {
+				if title == "Existing Title" {
+					return true, nil
+				}
+				return false, nil
+			},
+		}
+
+		bundleAPI := GetBundleAPIWithMocks(store.Datastore{Backend: mockedDatastore}, &datasetAPISDKMock.ClienterMock{}, false)
+
+		Convey("When putBundle is called with duplicate title", func() {
+			r := httptest.NewRequest("PUT", "/bundles/bundle-1", bytes.NewReader(updateRequestJSON))
+			r = mux.SetURLVars(r, map[string]string{"bundle-id": bundle1})
+			r.Header.Set("If-Match", "original-etag")
+			r.Header.Set("Authorization", "Bearer test-auth-token")
+			w := httptest.NewRecorder()
+
+			bundleAPI.putBundle(w, r)
+
+			Convey("Then it should return 400 Bad Request", func() {
+				So(w.Code, ShouldEqual, http.StatusBadRequest)
+
+				var errResp models.ErrorList
+				err := json.NewDecoder(w.Body).Decode(&errResp)
+				So(err, ShouldBeNil)
+
+				codeBadRequest := models.ErrInvalidParameters
+				expectedErrResp := models.ErrorList{
+					Errors: []*models.Error{
+						{
+							Code:        &codeBadRequest,
+							Description: apierrors.ErrorDescriptionMalformedRequest,
+							Source:      &models.Source{Field: "/title"},
+						},
+					},
+				}
+				So(errResp, ShouldResemble, expectedErrResp)
+			})
+		})
+	})
+}
+
+func TestPutBundle_InvalidStateTransition_Failure(t *testing.T) {
+	t.Parallel()
+
+	Convey("Given a PUT request with invalid state transition", t, func() {
+		now := time.Now().UTC()
+		existingBundle := &models.Bundle{
+			ID:        bundle1,
+			Title:     "Test Bundle",
+			ETag:      "original-etag",
+			State:     models.BundleStateDraft,
+			CreatedAt: &now,
+			CreatedBy: &models.User{Email: "creator@example.com"},
+		}
+
+		updateRequest := &models.Bundle{
+			Title:        "Test Bundle",
+			BundleType:   models.BundleTypeManual,
+			State:        models.BundleStatePublished,
+			ManagedBy:    models.ManagedByDataAdmin,
+			PreviewTeams: []models.PreviewTeam{{ID: "team-1"}},
+		}
+
+		updateRequestJSON, err := json.Marshal(updateRequest)
+		So(err, ShouldBeNil)
+
+		mockedDatastore := &storetest.StorerMock{
+			GetBundleFunc: func(ctx context.Context, id string) (*models.Bundle, error) {
+				return existingBundle, nil
+			},
+		}
+
+		bundleAPI := GetBundleAPIWithMocks(store.Datastore{Backend: mockedDatastore}, &datasetAPISDKMock.ClienterMock{}, false)
+
+		Convey("When putBundle is called with invalid state transition", func() {
+			r := httptest.NewRequest("PUT", "/bundles/bundle-1", bytes.NewReader(updateRequestJSON))
+			r = mux.SetURLVars(r, map[string]string{"bundle-id": bundle1})
+			r.Header.Set("If-Match", "original-etag")
+			r.Header.Set("Authorization", "Bearer test-auth-token")
+			w := httptest.NewRecorder()
+
+			bundleAPI.putBundle(w, r)
+
+			Convey("Then it should return 400 Bad Request", func() {
+				So(w.Code, ShouldEqual, http.StatusBadRequest)
+
+				var errResp models.ErrorList
+				err := json.NewDecoder(w.Body).Decode(&errResp)
+				So(err, ShouldBeNil)
+
+				codeBadRequest := models.ErrInvalidParameters
+				expectedErrResp := models.ErrorList{
+					Errors: []*models.Error{
+						{
+							Code:        &codeBadRequest,
+							Description: apierrors.ErrorDescriptionMalformedRequest,
+							Source:      &models.Source{Field: "/state"},
+						},
+					},
+				}
+				So(errResp, ShouldResemble, expectedErrResp)
+			})
+		})
+	})
+}
+
+func TestPutBundle_DatabaseErrors_Failure(t *testing.T) {
+	t.Parallel()
+
+	Convey("Given a PUT request that causes database errors", t, func() {
+		now := time.Now().UTC()
+		existingBundle := &models.Bundle{
+			ID:        bundle1,
+			Title:     "Original Title",
+			ETag:      "original-etag",
+			CreatedAt: &now,
+			CreatedBy: &models.User{Email: "creator@example.com"},
+		}
+
+		updateRequest := &models.Bundle{
+			Title:        "Updated Title",
+			BundleType:   models.BundleTypeManual,
+			State:        models.BundleStateDraft,
+			ManagedBy:    models.ManagedByDataAdmin,
+			PreviewTeams: []models.PreviewTeam{{ID: "team-1"}},
+		}
+
+		updateRequestJSON, err := json.Marshal(updateRequest)
+		So(err, ShouldBeNil)
+
+		Convey("When GetBundle fails with internal error", func() {
+			mockedDatastore := &storetest.StorerMock{
+				GetBundleFunc: func(ctx context.Context, id string) (*models.Bundle, error) {
+					return nil, errors.New("database connection failed")
+				},
+			}
+
+			bundleAPI := GetBundleAPIWithMocks(store.Datastore{Backend: mockedDatastore}, &datasetAPISDKMock.ClienterMock{}, false)
+
+			r := httptest.NewRequest("PUT", "/bundles/bundle-1", bytes.NewReader(updateRequestJSON))
+			r = mux.SetURLVars(r, map[string]string{"bundle-id": bundle1})
+			r.Header.Set("If-Match", "original-etag")
+			r.Header.Set("Authorization", "Bearer test-auth-token")
+			w := httptest.NewRecorder()
+
+			bundleAPI.putBundle(w, r)
+
+			So(w.Code, ShouldEqual, http.StatusInternalServerError)
+
+			var errResp models.ErrorList
+			err := json.NewDecoder(w.Body).Decode(&errResp)
+			So(err, ShouldBeNil)
+
+			codeInternalError := models.InternalError
+			expectedErrResp := models.ErrorList{
+				Errors: []*models.Error{
+					{
+						Code:        &codeInternalError,
+						Description: apierrors.ErrorDescriptionInternalError,
+					},
+				},
+			}
+			So(errResp, ShouldResemble, expectedErrResp)
+		})
+
+		Convey("When UpdateBundle fails", func() {
+			mockedDatastore := &storetest.StorerMock{
+				GetBundleFunc: func(ctx context.Context, id string) (*models.Bundle, error) {
+					return existingBundle, nil
+				},
+				CheckBundleExistsByTitleUpdateFunc: func(ctx context.Context, title, excludeID string) (bool, error) {
+					return false, nil
+				},
+				UpdateBundleFunc: func(ctx context.Context, bundleID string, bundle *models.Bundle) (*models.Bundle, error) {
+					return nil, errors.New("database update failed")
+				},
+			}
+
+			bundleAPI := GetBundleAPIWithMocks(store.Datastore{Backend: mockedDatastore}, &datasetAPISDKMock.ClienterMock{}, false)
+
+			r := httptest.NewRequest("PUT", "/bundles/bundle-1", bytes.NewReader(updateRequestJSON))
+			r = mux.SetURLVars(r, map[string]string{"bundle-id": bundle1})
+			r.Header.Set("If-Match", "original-etag")
+			r.Header.Set("Authorization", "Bearer test-auth-token")
+			w := httptest.NewRecorder()
+
+			bundleAPI.putBundle(w, r)
+
+			So(w.Code, ShouldEqual, http.StatusInternalServerError)
+		})
+
+		Convey("When UpdateBundleETag fails", func() {
+			mockedDatastore := &storetest.StorerMock{
+				GetBundleFunc: func(ctx context.Context, id string) (*models.Bundle, error) {
+					return existingBundle, nil
+				},
+				CheckBundleExistsByTitleUpdateFunc: func(ctx context.Context, title, excludeID string) (bool, error) {
+					return false, nil
+				},
+				UpdateBundleFunc: func(ctx context.Context, bundleID string, bundle *models.Bundle) (*models.Bundle, error) {
+					return bundle, nil
+				},
+				UpdateBundleETagFunc: func(ctx context.Context, bundleID, email string) (*models.Bundle, error) {
+					return nil, errors.New("failed to update ETag")
+				},
+			}
+
+			bundleAPI := GetBundleAPIWithMocks(store.Datastore{Backend: mockedDatastore}, &datasetAPISDKMock.ClienterMock{}, false)
+
+			r := httptest.NewRequest("PUT", "/bundles/bundle-1", bytes.NewReader(updateRequestJSON))
+			r = mux.SetURLVars(r, map[string]string{"bundle-id": bundle1})
+			r.Header.Set("If-Match", "original-etag")
+			r.Header.Set("Authorization", "Bearer test-auth-token")
+			w := httptest.NewRecorder()
+
+			bundleAPI.putBundle(w, r)
+
+			So(w.Code, ShouldEqual, http.StatusInternalServerError)
+		})
+
+		Convey("When CreateBundleEvent fails", func() {
+			mockedDatastore := &storetest.StorerMock{
+				GetBundleFunc: func(ctx context.Context, id string) (*models.Bundle, error) {
+					return existingBundle, nil
+				},
+				CheckBundleExistsByTitleUpdateFunc: func(ctx context.Context, title, excludeID string) (bool, error) {
+					return false, nil
+				},
+				UpdateBundleFunc: func(ctx context.Context, bundleID string, bundle *models.Bundle) (*models.Bundle, error) {
+					return bundle, nil
+				},
+				UpdateBundleETagFunc: func(ctx context.Context, bundleID, email string) (*models.Bundle, error) {
+					updatedBundle := *existingBundle
+					updatedBundle.ETag = newEtag
+					return &updatedBundle, nil
+				},
+				CreateBundleEventFunc: func(ctx context.Context, event *models.Event) error {
+					return errors.New("failed to create event")
+				},
+			}
+
+			bundleAPI := GetBundleAPIWithMocks(store.Datastore{Backend: mockedDatastore}, &datasetAPISDKMock.ClienterMock{}, false)
+
+			r := httptest.NewRequest("PUT", "/bundles/bundle-1", bytes.NewReader(updateRequestJSON))
+			r = mux.SetURLVars(r, map[string]string{"bundle-id": bundle1})
+			r.Header.Set("If-Match", "original-etag")
+			r.Header.Set("Authorization", "Bearer test-auth-token")
+			w := httptest.NewRecorder()
+
+			bundleAPI.putBundle(w, r)
+
+			So(w.Code, ShouldEqual, http.StatusInternalServerError)
+		})
+	})
+}
+
+func TestPutBundle_AuthenticationFailure(t *testing.T) {
+	t.Parallel()
+
+	Convey("Given a PUT request with invalid authentication", t, func() {
+		now := time.Now().UTC()
+		existingBundle := &models.Bundle{
+			ID:        bundle1,
+			Title:     "Original Title",
+			ETag:      "original-etag",
+			CreatedAt: &now,
+			CreatedBy: &models.User{Email: "creator@example.com"},
+		}
+
+		updateRequest := &models.Bundle{
+			Title:        "Updated Title",
+			BundleType:   models.BundleTypeManual,
+			State:        models.BundleStateDraft,
+			ManagedBy:    models.ManagedByDataAdmin,
+			PreviewTeams: []models.PreviewTeam{{ID: "team-1"}},
+		}
+
+		updateRequestJSON, err := json.Marshal(updateRequest)
+		So(err, ShouldBeNil)
+
+		mockedDatastore := &storetest.StorerMock{
+			GetBundleFunc: func(ctx context.Context, id string) (*models.Bundle, error) {
+				return existingBundle, nil
+			},
+			CheckBundleExistsByTitleUpdateFunc: func(ctx context.Context, title, excludeID string) (bool, error) {
+				return false, nil
+			},
+			UpdateBundleFunc: func(ctx context.Context, bundleID string, bundle *models.Bundle) (*models.Bundle, error) {
+				return bundle, nil
+			},
+		}
+
+		bundleAPI := GetBundleAPIWithMocks(store.Datastore{Backend: mockedDatastore}, &datasetAPISDKMock.ClienterMock{}, false)
+
+		Convey("When putBundle is called with invalid JWT", func() {
+			r := httptest.NewRequest("PUT", "/bundles/bundle-1", bytes.NewReader(updateRequestJSON))
+			r = mux.SetURLVars(r, map[string]string{"bundle-id": bundle1})
+			r.Header.Set("If-Match", "original-etag")
+			r.Header.Set("Authorization", "Bearer invalid-token")
+			w := httptest.NewRecorder()
+
+			bundleAPI.putBundle(w, r)
+
+			Convey("Then it should return 500 Internal Server Error", func() {
+				So(w.Code, ShouldEqual, http.StatusInternalServerError)
+
+				var errResp models.ErrorList
+				err := json.NewDecoder(w.Body).Decode(&errResp)
+				So(err, ShouldBeNil)
+
+				codeInternalError := models.InternalError
+				expectedErrResp := models.ErrorList{
+					Errors: []*models.Error{
+						{
+							Code:        &codeInternalError,
+							Description: apierrors.ErrorDescriptionInternalError,
+						},
+					},
+				}
+				So(errResp, ShouldResemble, expectedErrResp)
+			})
+		})
+	})
+}
+
+func ptrState(state models.State) *models.State {
+	return &state
+}

--- a/api/bundle_update_test.go
+++ b/api/bundle_update_test.go
@@ -14,8 +14,6 @@ import (
 	"github.com/ONSdigital/dis-bundle-api/models"
 	"github.com/ONSdigital/dis-bundle-api/store"
 	storetest "github.com/ONSdigital/dis-bundle-api/store/datastoretest"
-	datasetAPIModels "github.com/ONSdigital/dp-dataset-api/models"
-	datasetAPISDK "github.com/ONSdigital/dp-dataset-api/sdk"
 	datasetAPISDKMock "github.com/ONSdigital/dp-dataset-api/sdk/mocks"
 	"github.com/gorilla/mux"
 	. "github.com/smartystreets/goconvey/convey"
@@ -93,6 +91,9 @@ func TestPutBundle_Success(t *testing.T) {
 				}
 				return errors.New("failed to create event")
 			},
+			GetContentItemsByBundleIDFunc: func(ctx context.Context, bundleID string) ([]*models.ContentItem, error) {
+				return []*models.ContentItem{}, nil
+			},
 		}
 
 		bundleAPI := GetBundleAPIWithMocks(store.Datastore{Backend: mockedDatastore}, &datasetAPISDKMock.ClienterMock{}, false)
@@ -117,198 +118,6 @@ func TestPutBundle_Success(t *testing.T) {
 				So(err, ShouldBeNil)
 				So(response.ID, ShouldEqual, bundle1)
 				So(response.Title, ShouldEqual, title1)
-			})
-		})
-	})
-}
-
-func TestPutBundle_StateTransition_Success(t *testing.T) {
-	t.Parallel()
-
-	Convey("Given a PUT request with valid state transition", t, func() {
-		now := time.Now().UTC()
-		existingBundle := &models.Bundle{
-			ID:           bundle1,
-			Title:        "Test Bundle",
-			BundleType:   models.BundleTypeManual,
-			ETag:         "original-etag",
-			State:        models.BundleStateDraft,
-			CreatedAt:    &now,
-			CreatedBy:    &models.User{Email: "creator@example.com"},
-			UpdatedAt:    &now,
-			ManagedBy:    models.ManagedByDataAdmin,
-			PreviewTeams: []models.PreviewTeam{{ID: "team-1"}},
-		}
-
-		updateRequest := &models.Bundle{
-			Title:        "Test Bundle",
-			BundleType:   models.BundleTypeManual,
-			State:        models.BundleStateInReview,
-			ManagedBy:    models.ManagedByDataAdmin,
-			PreviewTeams: []models.PreviewTeam{{ID: "team-1"}},
-		}
-
-		updateRequestJSON, err := json.Marshal(updateRequest)
-		So(err, ShouldBeNil)
-
-		mockedDatastore := &storetest.StorerMock{
-			GetBundleFunc: func(ctx context.Context, id string) (*models.Bundle, error) {
-				return existingBundle, nil
-			},
-			CheckBundleExistsByTitleUpdateFunc: func(ctx context.Context, title, excludeID string) (bool, error) {
-				return false, nil
-			},
-			UpdateBundleFunc: func(ctx context.Context, bundleID string, bundle *models.Bundle) (*models.Bundle, error) {
-				return bundle, nil
-			},
-			UpdateBundleETagFunc: func(ctx context.Context, bundleID, email string) (*models.Bundle, error) {
-				updatedBundle := *existingBundle
-				updatedBundle.State = models.BundleStateInReview
-				updatedBundle.ETag = newEtag
-				return &updatedBundle, nil
-			},
-			CreateBundleEventFunc: func(ctx context.Context, event *models.Event) error {
-				return nil
-			},
-		}
-
-		bundleAPI := GetBundleAPIWithMocks(store.Datastore{Backend: mockedDatastore}, &datasetAPISDKMock.ClienterMock{}, false)
-
-		Convey("When putBundle is called with valid state transition", func() {
-			r := httptest.NewRequest("PUT", "/bundles/bundle-1", bytes.NewReader(updateRequestJSON))
-			r = mux.SetURLVars(r, map[string]string{"bundle-id": bundle1})
-			r.Header.Set("If-Match", "original-etag")
-			r.Header.Set("Authorization", "Bearer test-auth-token")
-			w := httptest.NewRecorder()
-
-			bundleAPI.putBundle(w, r)
-
-			Convey("Then it should return 200 OK with updated state", func() {
-				So(w.Code, ShouldEqual, http.StatusOK)
-
-				var response models.Bundle
-				err := json.NewDecoder(w.Body).Decode(&response)
-				So(err, ShouldBeNil)
-				So(response.State, ShouldEqual, models.BundleStateInReview)
-			})
-		})
-	})
-}
-
-func TestPutBundle_StateTransitionToPublished_UpdatesContentItems(t *testing.T) {
-	t.Parallel()
-
-	Convey("Given a PUT request transitioning to PUBLISHED state", t, func() {
-		now := time.Now().UTC()
-		existingBundle := &models.Bundle{
-			ID:           bundle1,
-			Title:        "Test Bundle",
-			BundleType:   models.BundleTypeManual,
-			ETag:         "original-etag",
-			State:        models.BundleStateApproved,
-			CreatedAt:    &now,
-			CreatedBy:    &models.User{Email: "creator@example.com"},
-			UpdatedAt:    &now,
-			ManagedBy:    models.ManagedByDataAdmin,
-			PreviewTeams: []models.PreviewTeam{{ID: "team-1"}},
-		}
-
-		updateRequest := &models.Bundle{
-			Title:        "Test Bundle",
-			BundleType:   models.BundleTypeManual,
-			State:        models.BundleStatePublished,
-			ManagedBy:    models.ManagedByDataAdmin,
-			PreviewTeams: []models.PreviewTeam{{ID: "team-1"}},
-		}
-
-		updateRequestJSON, err := json.Marshal(updateRequest)
-		So(err, ShouldBeNil)
-
-		contentItems := []*models.ContentItem{
-			{
-				ID:       content1,
-				BundleID: bundle1,
-				Metadata: models.Metadata{
-					DatasetID: dataset1,
-					Title:     "Old Title",
-				},
-				State: ptrState(models.StateApproved),
-			},
-		}
-
-		mockedDatastore := &storetest.StorerMock{
-			GetBundleFunc: func(ctx context.Context, id string) (*models.Bundle, error) {
-				return existingBundle, nil
-			},
-			CheckBundleExistsByTitleUpdateFunc: func(ctx context.Context, title, excludeID string) (bool, error) {
-				return false, nil
-			},
-			UpdateBundleFunc: func(ctx context.Context, bundleID string, bundle *models.Bundle) (*models.Bundle, error) {
-				return bundle, nil
-			},
-			UpdateBundleETagFunc: func(ctx context.Context, bundleID, email string) (*models.Bundle, error) {
-				updatedBundle := *existingBundle
-				updatedBundle.State = models.BundleStatePublished
-				updatedBundle.ETag = newEtag
-				return &updatedBundle, nil
-			},
-			CreateBundleEventFunc: func(ctx context.Context, event *models.Event) error {
-				return nil
-			},
-			GetContentItemsByBundleIDFunc: func(ctx context.Context, bundleID string) ([]*models.ContentItem, error) {
-				if bundleID == bundle1 {
-					return contentItems, nil
-				}
-				return nil, errors.New("bundle not found")
-			},
-			UpdateContentItemDatasetInfoFunc: func(ctx context.Context, contentItemID, title, state string) error {
-				if contentItemID == content1 && title == "Dataset Title" && state == "published" {
-					return nil
-				}
-				return errors.New("failed to update content item")
-			},
-		}
-
-		mockDatasetAPIClient := &datasetAPISDKMock.ClienterMock{
-			GetDatasetFunc: func(ctx context.Context, headers datasetAPISDK.Headers, collectionID, datasetID string) (datasetAPIModels.Dataset, error) {
-				if datasetID == dataset1 {
-					return datasetAPIModels.Dataset{
-						ID:    datasetID,
-						Title: "Dataset Title",
-						State: "published",
-					}, nil
-				}
-				return datasetAPIModels.Dataset{}, errors.New("dataset not found")
-			},
-		}
-
-		bundleAPI := GetBundleAPIWithMocks(store.Datastore{Backend: mockedDatastore}, &datasetAPISDKMock.ClienterMock{}, false)
-		bundleAPI.stateMachineBundleAPI.DatasetAPIClient = mockDatasetAPIClient
-
-		Convey("When putBundle is called with transition to PUBLISHED", func() {
-			r := httptest.NewRequest("PUT", "/bundles/bundle-1", bytes.NewReader(updateRequestJSON))
-			r = mux.SetURLVars(r, map[string]string{"bundle-id": bundle1})
-			r.Header.Set("If-Match", "original-etag")
-			r.Header.Set("Authorization", "Bearer test-auth-token")
-			w := httptest.NewRecorder()
-
-			bundleAPI.putBundle(w, r)
-
-			Convey("Then it should return 200 OK and update content items", func() {
-				So(w.Code, ShouldEqual, http.StatusOK)
-
-				var response models.Bundle
-				err := json.NewDecoder(w.Body).Decode(&response)
-				So(err, ShouldBeNil)
-				So(response.State, ShouldEqual, models.BundleStatePublished)
-
-				So(len(mockedDatastore.GetContentItemsByBundleIDCalls()), ShouldEqual, 1)
-				So(mockedDatastore.GetContentItemsByBundleIDCalls()[0].BundleID, ShouldEqual, bundle1)
-
-				So(len(mockedDatastore.UpdateContentItemDatasetInfoCalls()), ShouldEqual, 1)
-				So(mockedDatastore.UpdateContentItemDatasetInfoCalls()[0].ContentItemID, ShouldEqual, content1)
-				So(mockedDatastore.UpdateContentItemDatasetInfoCalls()[0].Title, ShouldEqual, "Dataset Title")
-				So(mockedDatastore.UpdateContentItemDatasetInfoCalls()[0].State, ShouldEqual, "published")
 			})
 		})
 	})
@@ -474,154 +283,10 @@ func TestPutBundle_MalformedJSON_Failure(t *testing.T) {
 	})
 }
 
-func TestPutBundle_DuplicateTitle_Failure(t *testing.T) {
+func TestPutBundle_BundleNotFound_Failure(t *testing.T) {
 	t.Parallel()
 
-	Convey("Given a PUT request with duplicate title", t, func() {
-		now := time.Now().UTC()
-		existingBundle := &models.Bundle{
-			ID:        bundle1,
-			Title:     "Original Title",
-			ETag:      "original-etag",
-			CreatedAt: &now,
-			CreatedBy: &models.User{Email: "creator@example.com"},
-		}
-
-		updateRequest := &models.Bundle{
-			Title:        "Existing Title",
-			BundleType:   models.BundleTypeManual,
-			State:        models.BundleStateDraft,
-			ManagedBy:    models.ManagedByDataAdmin,
-			PreviewTeams: []models.PreviewTeam{{ID: "team-1"}},
-		}
-
-		updateRequestJSON, err := json.Marshal(updateRequest)
-		So(err, ShouldBeNil)
-
-		mockedDatastore := &storetest.StorerMock{
-			GetBundleFunc: func(ctx context.Context, id string) (*models.Bundle, error) {
-				return existingBundle, nil
-			},
-			CheckBundleExistsByTitleUpdateFunc: func(ctx context.Context, title, excludeID string) (bool, error) {
-				if title == "Existing Title" {
-					return true, nil
-				}
-				return false, nil
-			},
-		}
-
-		bundleAPI := GetBundleAPIWithMocks(store.Datastore{Backend: mockedDatastore}, &datasetAPISDKMock.ClienterMock{}, false)
-
-		Convey("When putBundle is called with duplicate title", func() {
-			r := httptest.NewRequest("PUT", "/bundles/bundle-1", bytes.NewReader(updateRequestJSON))
-			r = mux.SetURLVars(r, map[string]string{"bundle-id": bundle1})
-			r.Header.Set("If-Match", "original-etag")
-			r.Header.Set("Authorization", "Bearer test-auth-token")
-			w := httptest.NewRecorder()
-
-			bundleAPI.putBundle(w, r)
-
-			Convey("Then it should return 400 Bad Request", func() {
-				So(w.Code, ShouldEqual, http.StatusBadRequest)
-
-				var errResp models.ErrorList
-				err := json.NewDecoder(w.Body).Decode(&errResp)
-				So(err, ShouldBeNil)
-
-				codeBadRequest := models.ErrInvalidParameters
-				expectedErrResp := models.ErrorList{
-					Errors: []*models.Error{
-						{
-							Code:        &codeBadRequest,
-							Description: apierrors.ErrorDescriptionMalformedRequest,
-							Source:      &models.Source{Field: "/title"},
-						},
-					},
-				}
-				So(errResp, ShouldResemble, expectedErrResp)
-			})
-		})
-	})
-}
-
-func TestPutBundle_InvalidStateTransition_Failure(t *testing.T) {
-	t.Parallel()
-
-	Convey("Given a PUT request with invalid state transition", t, func() {
-		now := time.Now().UTC()
-		existingBundle := &models.Bundle{
-			ID:        bundle1,
-			Title:     "Test Bundle",
-			ETag:      "original-etag",
-			State:     models.BundleStateDraft,
-			CreatedAt: &now,
-			CreatedBy: &models.User{Email: "creator@example.com"},
-		}
-
-		updateRequest := &models.Bundle{
-			Title:        "Test Bundle",
-			BundleType:   models.BundleTypeManual,
-			State:        models.BundleStatePublished,
-			ManagedBy:    models.ManagedByDataAdmin,
-			PreviewTeams: []models.PreviewTeam{{ID: "team-1"}},
-		}
-
-		updateRequestJSON, err := json.Marshal(updateRequest)
-		So(err, ShouldBeNil)
-
-		mockedDatastore := &storetest.StorerMock{
-			GetBundleFunc: func(ctx context.Context, id string) (*models.Bundle, error) {
-				return existingBundle, nil
-			},
-		}
-
-		bundleAPI := GetBundleAPIWithMocks(store.Datastore{Backend: mockedDatastore}, &datasetAPISDKMock.ClienterMock{}, false)
-
-		Convey("When putBundle is called with invalid state transition", func() {
-			r := httptest.NewRequest("PUT", "/bundles/bundle-1", bytes.NewReader(updateRequestJSON))
-			r = mux.SetURLVars(r, map[string]string{"bundle-id": bundle1})
-			r.Header.Set("If-Match", "original-etag")
-			r.Header.Set("Authorization", "Bearer test-auth-token")
-			w := httptest.NewRecorder()
-
-			bundleAPI.putBundle(w, r)
-
-			Convey("Then it should return 400 Bad Request", func() {
-				So(w.Code, ShouldEqual, http.StatusBadRequest)
-
-				var errResp models.ErrorList
-				err := json.NewDecoder(w.Body).Decode(&errResp)
-				So(err, ShouldBeNil)
-
-				codeBadRequest := models.ErrInvalidParameters
-				expectedErrResp := models.ErrorList{
-					Errors: []*models.Error{
-						{
-							Code:        &codeBadRequest,
-							Description: apierrors.ErrorDescriptionMalformedRequest,
-							Source:      &models.Source{Field: "/state"},
-						},
-					},
-				}
-				So(errResp, ShouldResemble, expectedErrResp)
-			})
-		})
-	})
-}
-
-func TestPutBundle_DatabaseErrors_Failure(t *testing.T) {
-	t.Parallel()
-
-	Convey("Given a PUT request that causes database errors", t, func() {
-		now := time.Now().UTC()
-		existingBundle := &models.Bundle{
-			ID:        bundle1,
-			Title:     "Original Title",
-			ETag:      "original-etag",
-			CreatedAt: &now,
-			CreatedBy: &models.User{Email: "creator@example.com"},
-		}
-
+	Convey("Given a PUT request for non-existent bundle", t, func() {
 		updateRequest := &models.Bundle{
 			Title:        "Updated Title",
 			BundleType:   models.BundleTypeManual,
@@ -633,128 +298,41 @@ func TestPutBundle_DatabaseErrors_Failure(t *testing.T) {
 		updateRequestJSON, err := json.Marshal(updateRequest)
 		So(err, ShouldBeNil)
 
-		Convey("When GetBundle fails with internal error", func() {
-			mockedDatastore := &storetest.StorerMock{
-				GetBundleFunc: func(ctx context.Context, id string) (*models.Bundle, error) {
-					return nil, errors.New("database connection failed")
-				},
-			}
+		mockedDatastore := &storetest.StorerMock{
+			GetBundleFunc: func(ctx context.Context, bundleID string) (*models.Bundle, error) {
+				return nil, apierrors.ErrBundleNotFound
+			},
+		}
 
-			bundleAPI := GetBundleAPIWithMocks(store.Datastore{Backend: mockedDatastore}, &datasetAPISDKMock.ClienterMock{}, false)
+		bundleAPI := GetBundleAPIWithMocks(store.Datastore{Backend: mockedDatastore}, &datasetAPISDKMock.ClienterMock{}, false)
 
-			r := httptest.NewRequest("PUT", "/bundles/bundle-1", bytes.NewReader(updateRequestJSON))
-			r = mux.SetURLVars(r, map[string]string{"bundle-id": bundle1})
-			r.Header.Set("If-Match", "original-etag")
+		Convey("When putBundle is called", func() {
+			r := httptest.NewRequest("PUT", "/bundles/bundle-missing", bytes.NewReader(updateRequestJSON))
+			r = mux.SetURLVars(r, map[string]string{"bundle-id": "bundle-missing"})
+			r.Header.Set("If-Match", "some-etag")
 			r.Header.Set("Authorization", "Bearer test-auth-token")
 			w := httptest.NewRecorder()
 
 			bundleAPI.putBundle(w, r)
 
-			So(w.Code, ShouldEqual, http.StatusInternalServerError)
+			Convey("Then it should return 404 Not Found", func() {
+				So(w.Code, ShouldEqual, http.StatusNotFound)
 
-			var errResp models.ErrorList
-			err := json.NewDecoder(w.Body).Decode(&errResp)
-			So(err, ShouldBeNil)
+				var errResp models.ErrorList
+				err := json.NewDecoder(w.Body).Decode(&errResp)
+				So(err, ShouldBeNil)
 
-			codeInternalError := models.InternalError
-			expectedErrResp := models.ErrorList{
-				Errors: []*models.Error{
-					{
-						Code:        &codeInternalError,
-						Description: apierrors.ErrorDescriptionInternalError,
+				codeNotFound := models.NotFound
+				expectedErrResp := models.ErrorList{
+					Errors: []*models.Error{
+						{
+							Code:        &codeNotFound,
+							Description: apierrors.ErrorDescriptionNotFound,
+						},
 					},
-				},
-			}
-			So(errResp, ShouldResemble, expectedErrResp)
-		})
-
-		Convey("When UpdateBundle fails", func() {
-			mockedDatastore := &storetest.StorerMock{
-				GetBundleFunc: func(ctx context.Context, id string) (*models.Bundle, error) {
-					return existingBundle, nil
-				},
-				CheckBundleExistsByTitleUpdateFunc: func(ctx context.Context, title, excludeID string) (bool, error) {
-					return false, nil
-				},
-				UpdateBundleFunc: func(ctx context.Context, bundleID string, bundle *models.Bundle) (*models.Bundle, error) {
-					return nil, errors.New("database update failed")
-				},
-			}
-
-			bundleAPI := GetBundleAPIWithMocks(store.Datastore{Backend: mockedDatastore}, &datasetAPISDKMock.ClienterMock{}, false)
-
-			r := httptest.NewRequest("PUT", "/bundles/bundle-1", bytes.NewReader(updateRequestJSON))
-			r = mux.SetURLVars(r, map[string]string{"bundle-id": bundle1})
-			r.Header.Set("If-Match", "original-etag")
-			r.Header.Set("Authorization", "Bearer test-auth-token")
-			w := httptest.NewRecorder()
-
-			bundleAPI.putBundle(w, r)
-
-			So(w.Code, ShouldEqual, http.StatusInternalServerError)
-		})
-
-		Convey("When UpdateBundleETag fails", func() {
-			mockedDatastore := &storetest.StorerMock{
-				GetBundleFunc: func(ctx context.Context, id string) (*models.Bundle, error) {
-					return existingBundle, nil
-				},
-				CheckBundleExistsByTitleUpdateFunc: func(ctx context.Context, title, excludeID string) (bool, error) {
-					return false, nil
-				},
-				UpdateBundleFunc: func(ctx context.Context, bundleID string, bundle *models.Bundle) (*models.Bundle, error) {
-					return bundle, nil
-				},
-				UpdateBundleETagFunc: func(ctx context.Context, bundleID, email string) (*models.Bundle, error) {
-					return nil, errors.New("failed to update ETag")
-				},
-			}
-
-			bundleAPI := GetBundleAPIWithMocks(store.Datastore{Backend: mockedDatastore}, &datasetAPISDKMock.ClienterMock{}, false)
-
-			r := httptest.NewRequest("PUT", "/bundles/bundle-1", bytes.NewReader(updateRequestJSON))
-			r = mux.SetURLVars(r, map[string]string{"bundle-id": bundle1})
-			r.Header.Set("If-Match", "original-etag")
-			r.Header.Set("Authorization", "Bearer test-auth-token")
-			w := httptest.NewRecorder()
-
-			bundleAPI.putBundle(w, r)
-
-			So(w.Code, ShouldEqual, http.StatusInternalServerError)
-		})
-
-		Convey("When CreateBundleEvent fails", func() {
-			mockedDatastore := &storetest.StorerMock{
-				GetBundleFunc: func(ctx context.Context, id string) (*models.Bundle, error) {
-					return existingBundle, nil
-				},
-				CheckBundleExistsByTitleUpdateFunc: func(ctx context.Context, title, excludeID string) (bool, error) {
-					return false, nil
-				},
-				UpdateBundleFunc: func(ctx context.Context, bundleID string, bundle *models.Bundle) (*models.Bundle, error) {
-					return bundle, nil
-				},
-				UpdateBundleETagFunc: func(ctx context.Context, bundleID, email string) (*models.Bundle, error) {
-					updatedBundle := *existingBundle
-					updatedBundle.ETag = newEtag
-					return &updatedBundle, nil
-				},
-				CreateBundleEventFunc: func(ctx context.Context, event *models.Event) error {
-					return errors.New("failed to create event")
-				},
-			}
-
-			bundleAPI := GetBundleAPIWithMocks(store.Datastore{Backend: mockedDatastore}, &datasetAPISDKMock.ClienterMock{}, false)
-
-			r := httptest.NewRequest("PUT", "/bundles/bundle-1", bytes.NewReader(updateRequestJSON))
-			r = mux.SetURLVars(r, map[string]string{"bundle-id": bundle1})
-			r.Header.Set("If-Match", "original-etag")
-			r.Header.Set("Authorization", "Bearer test-auth-token")
-			w := httptest.NewRecorder()
-
-			bundleAPI.putBundle(w, r)
-
-			So(w.Code, ShouldEqual, http.StatusInternalServerError)
+				}
+				So(errResp, ShouldResemble, expectedErrResp)
+			})
 		})
 	})
 }
@@ -763,15 +341,6 @@ func TestPutBundle_AuthenticationFailure(t *testing.T) {
 	t.Parallel()
 
 	Convey("Given a PUT request with invalid authentication", t, func() {
-		now := time.Now().UTC()
-		existingBundle := &models.Bundle{
-			ID:        bundle1,
-			Title:     "Original Title",
-			ETag:      "original-etag",
-			CreatedAt: &now,
-			CreatedBy: &models.User{Email: "creator@example.com"},
-		}
-
 		updateRequest := &models.Bundle{
 			Title:        "Updated Title",
 			BundleType:   models.BundleTypeManual,
@@ -783,19 +352,7 @@ func TestPutBundle_AuthenticationFailure(t *testing.T) {
 		updateRequestJSON, err := json.Marshal(updateRequest)
 		So(err, ShouldBeNil)
 
-		mockedDatastore := &storetest.StorerMock{
-			GetBundleFunc: func(ctx context.Context, id string) (*models.Bundle, error) {
-				return existingBundle, nil
-			},
-			CheckBundleExistsByTitleUpdateFunc: func(ctx context.Context, title, excludeID string) (bool, error) {
-				return false, nil
-			},
-			UpdateBundleFunc: func(ctx context.Context, bundleID string, bundle *models.Bundle) (*models.Bundle, error) {
-				return bundle, nil
-			},
-		}
-
-		bundleAPI := GetBundleAPIWithMocks(store.Datastore{Backend: mockedDatastore}, &datasetAPISDKMock.ClienterMock{}, false)
+		bundleAPI := GetBundleAPIWithMocks(store.Datastore{Backend: &storetest.StorerMock{}}, &datasetAPISDKMock.ClienterMock{}, false)
 
 		Convey("When putBundle is called with invalid JWT", func() {
 			r := httptest.NewRequest("PUT", "/bundles/bundle-1", bytes.NewReader(updateRequestJSON))
@@ -813,7 +370,7 @@ func TestPutBundle_AuthenticationFailure(t *testing.T) {
 				err := json.NewDecoder(w.Body).Decode(&errResp)
 				So(err, ShouldBeNil)
 
-				codeInternalError := models.InternalError
+				codeInternalError := models.CodeInternalServerError
 				expectedErrResp := models.ErrorList{
 					Errors: []*models.Error{
 						{
@@ -826,8 +383,4 @@ func TestPutBundle_AuthenticationFailure(t *testing.T) {
 			})
 		})
 	})
-}
-
-func ptrState(state models.State) *models.State {
-	return &state
 }

--- a/application/application.go
+++ b/application/application.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ONSdigital/dis-bundle-api/apierrors"
 	errs "github.com/ONSdigital/dis-bundle-api/apierrors"
 	"github.com/ONSdigital/dis-bundle-api/filters"
 	"github.com/ONSdigital/dis-bundle-api/models"
@@ -543,7 +542,7 @@ func (s *StateMachineBundleAPI) handleStateTransition(ctx context.Context, bundl
 			if strings.Contains(err.Error(), "state not allowed to transition") ||
 				strings.Contains(err.Error(), "not all bundle contents are approved") ||
 				strings.Contains(err.Error(), "incorrect state value") {
-				return false, apierrors.ErrInvalidTransition
+				return false, errs.ErrInvalidTransition
 			}
 			return false, err
 		}
@@ -634,7 +633,7 @@ func (s *StateMachineBundleAPI) UpdateContentItemsWithDatasetInfo(ctx context.Co
 					"content_item_id": contentItem.ID,
 					"dataset_id":      contentItem.Metadata.DatasetID,
 				})
-				return apierrors.ErrNotFound
+				return errs.ErrNotFound
 			}
 
 			return err

--- a/application/application.go
+++ b/application/application.go
@@ -462,7 +462,7 @@ func (s *StateMachineBundleAPI) GetBundleContents(ctx context.Context, bundleID 
 	return contentResults, totalCount, nil
 }
 
-func (s *StateMachineBundleAPI) UpdateBundleWIP(ctx context.Context, bundleID string, bundleUpdate, currentBundle *models.Bundle, entityData *models.AuthEntityData, authHeaders datasetAPISDK.Headers) (*models.Bundle, error) {
+func (s *StateMachineBundleAPI) PutBundle(ctx context.Context, bundleID string, bundleUpdate, currentBundle *models.Bundle, entityData *models.AuthEntityData, authHeaders datasetAPISDK.Headers) (*models.Bundle, error) {
 	logdata := log.Data{"bundle_id": bundleID}
 	userID := entityData.EntityData.UserID
 

--- a/application/application.go
+++ b/application/application.go
@@ -129,6 +129,22 @@ func (s *StateMachineBundleAPI) CreateBundleEvent(ctx context.Context, event *mo
 	return s.Datastore.CreateBundleEvent(ctx, event)
 }
 
+func (s *StateMachineBundleAPI) UpdateBundle(ctx context.Context, bundleID string, bundle *models.Bundle) (*models.Bundle, error) {
+	return s.Datastore.UpdateBundle(ctx, bundleID, bundle)
+}
+
+func (s *StateMachineBundleAPI) CheckBundleExistsByTitleUpdate(ctx context.Context, title, excludeID string) (bool, error) {
+	return s.Datastore.CheckBundleExistsByTitleUpdate(ctx, title, excludeID)
+}
+
+func (s *StateMachineBundleAPI) GetContentItemsByBundleID(ctx context.Context, bundleID string) ([]*models.ContentItem, error) {
+	return s.Datastore.GetContentItemsByBundleID(ctx, bundleID)
+}
+
+func (s *StateMachineBundleAPI) UpdateContentItemDatasetInfo(ctx context.Context, contentItemID, title, state string) error {
+	return s.Datastore.UpdateContentItemDatasetInfo(ctx, contentItemID, title, state)
+}
+
 func (s *StateMachineBundleAPI) GetBundleAndValidateETag(ctx context.Context, bundleID, suppliedETag string) (*models.Bundle, error) {
 	bundle, err := s.Datastore.GetBundle(ctx, bundleID)
 

--- a/application/application_test.go
+++ b/application/application_test.go
@@ -1507,7 +1507,7 @@ func TestDeleteBundle_Failure_CreateEventFromBundle(t *testing.T) {
 	})
 }
 
-func TestUpdateBundleWIP_Success(t *testing.T) {
+func TestPutBundle_Success(t *testing.T) {
 	Convey("Given a StateMachineBundleAPI with mocked dependencies", t, func() {
 		ctx := context.Background()
 		bundleID := "bundle-123"

--- a/application/application_test.go
+++ b/application/application_test.go
@@ -1555,7 +1555,7 @@ func TestUpdateBundleWIP_Success(t *testing.T) {
 		}
 
 		Convey("When UpdateBundleWIP is called with no state change", func() {
-			result, err := stateMachine.UpdateBundleWIP(ctx, bundleID, bundleUpdate, currentBundle, authEntityData, authHeaders)
+			result, err := stateMachine.PutBundle(ctx, bundleID, bundleUpdate, currentBundle, authEntityData, authHeaders)
 
 			Convey("Then it should update the bundle successfully", func() {
 				So(err, ShouldBeNil)

--- a/application/state_machine.go
+++ b/application/state_machine.go
@@ -183,9 +183,9 @@ func (*StateMachine) transitionContentItem(ctx context.Context, bundle *models.B
 		return apierrors.ErrInvalidBundleState
 	}
 
-	if err := stateMachineBundleAPI.updateVersionStateForContentItem(ctx, contentItem, targetState, authEntityData.ServiceToken); err != nil {
-		return err
-	}
+	// if err := stateMachineBundleAPI.updateVersionStateForContentItem(ctx, contentItem, targetState, authEntityData.ServiceToken); err != nil {
+	// 	return err
+	// }
 
 	if err := stateMachineBundleAPI.Datastore.UpdateContentItemState(ctx, contentItem.ID, targetState.String()); err != nil {
 		return err

--- a/application/state_machine.go
+++ b/application/state_machine.go
@@ -183,9 +183,9 @@ func (*StateMachine) transitionContentItem(ctx context.Context, bundle *models.B
 		return apierrors.ErrInvalidBundleState
 	}
 
-	// if err := stateMachineBundleAPI.updateVersionStateForContentItem(ctx, contentItem, targetState, authEntityData.ServiceToken); err != nil {
-	// 	return err
-	// }
+	if err := stateMachineBundleAPI.updateVersionStateForContentItem(ctx, contentItem, targetState, authEntityData.ServiceToken); err != nil {
+		return err
+	}
 
 	if err := stateMachineBundleAPI.Datastore.UpdateContentItemState(ctx, contentItem.ID, targetState.String()); err != nil {
 		return err

--- a/features/bundle_update.feature
+++ b/features/bundle_update.feature
@@ -1,0 +1,519 @@
+Feature: Update a bundle - PUT /bundles/{id}
+
+    Background:
+        Given I have these bundles:
+            """
+            [
+                {
+                    "id": "bundle-1",
+                    "bundle_type": "MANUAL",
+                    "created_by": {
+                        "email": "publisher@ons.gov.uk"
+                    },
+                    "created_at": "2025-04-03T11:25:00Z",
+                    "last_updated_by": {
+                        "email": "publisher@ons.gov.uk"
+                    },
+                    "preview_teams": [
+                        {
+                            "id": "890m231k-98df-11ec-b909-0242ac120002"
+                        }
+                    ],
+                    "state": "DRAFT",
+                    "title": "Original Bundle Title",
+                    "updated_at": "2025-04-03T11:25:00Z",
+                    "managed_by": "DATA-ADMIN"
+                },
+                {
+                    "id": "bundle-2",
+                    "bundle_type": "SCHEDULED",
+                    "created_by": {
+                        "email": "publisher@ons.gov.uk"
+                    },
+                    "created_at": "2025-04-04T13:40:00Z",
+                    "last_updated_by": {
+                        "email": "publisher@ons.gov.uk"
+                    },
+                    "preview_teams": [
+                        {
+                            "id": "567j908h-98df-11ec-b909-0242ac120002"
+                        }
+                    ],
+                    "scheduled_at": "2025-05-05T08:00:00Z",
+                    "state": "IN_REVIEW",
+                    "title": "Scheduled Bundle",
+                    "updated_at": "2025-04-04T13:40:00Z",
+                    "managed_by": "WAGTAIL"
+                },
+                {
+                    "id": "bundle-3",
+                    "bundle_type": "MANUAL",
+                    "created_by": {
+                        "email": "publisher@ons.gov.uk"
+                    },
+                    "created_at": "2025-04-05T13:40:00Z",
+                    "last_updated_by": {
+                        "email": "publisher@ons.gov.uk"
+                    },
+                    "preview_teams": [
+                        {
+                            "id": "567j908h-98df-11ec-b909-0242ac120002"
+                        }
+                    ],
+                    "state": "APPROVED",
+                    "title": "Approved Bundle",
+                    "updated_at": "2025-04-05T13:40:00Z",
+                    "managed_by": "DATA-ADMIN"
+                }
+            ]
+            """
+
+Scenario: PUT /bundles/{id} successfully updates a bundle
+        Given I am an admin user
+        And I set the header "If-Match" to "etag-bundle-1"
+        When I PUT "/bundles/bundle-1"
+            """
+            {
+                "bundle_type": "MANUAL",
+                "preview_teams": [
+                    {
+                        "id": "890m231k-98df-11ec-b909-0242ac120002"
+                    }
+                ],
+                "state": "DRAFT",
+                "title": "Updated Bundle Title",
+                "managed_by": "DATA-ADMIN"
+            }
+            """
+        Then the HTTP status code should be "200"
+        And the response header "Content-Type" should be "application/json"
+        And the response header "Cache-Control" should be "no-store"
+        And the response header "ETag" should not be empty
+        And the response should contain with dynamic timestamp:
+            """
+            {
+                "bundle_type": "MANUAL",
+                "created_at": "2025-04-03T11:25:00Z",
+                "created_by": {
+                    "email": "publisher@ons.gov.uk"
+                },
+                "id": "bundle-1",
+                "last_updated_by": {
+                    "email": "janedoe@example.com"
+                },
+                "managed_by": "DATA-ADMIN",
+                "preview_teams": [
+                    {
+                        "id": "890m231k-98df-11ec-b909-0242ac120002"
+                    }
+                ],
+                "state": "DRAFT",
+                "title": "Updated Bundle Title",
+                "updated_at": "{{DYNAMIC_TIMESTAMP}}"
+            }
+            """
+
+    Scenario: PUT /bundles/{id} with state transition from DRAFT to IN_REVIEW
+        Given I am an admin user
+        And I set the header "If-Match" to "etag-bundle-1"
+        When I PUT "/bundles/bundle-1"
+            """
+            {
+                "bundle_type": "MANUAL",
+                "preview_teams": [
+                    {
+                        "id": "890m231k-98df-11ec-b909-0242ac120002"
+                    }
+                ],
+                "state": "IN_REVIEW",
+                "title": "Bundle Moving to Review",
+                "managed_by": "DATA-ADMIN"
+            }
+            """
+        Then the HTTP status code should be "200"
+        And the response should contain with dynamic timestamp:
+            """
+            {
+                "bundle_type": "MANUAL",
+                "created_at": "2025-04-03T11:25:00Z",
+                "created_by": {
+                    "email": "publisher@ons.gov.uk"
+                },
+                "id": "bundle-1",
+                "last_updated_by": {
+                    "email": "janedoe@example.com"
+                },
+                "managed_by": "DATA-ADMIN",
+                "preview_teams": [
+                    {
+                        "id": "890m231k-98df-11ec-b909-0242ac120002"
+                    }
+                ],
+                "state": "IN_REVIEW",
+                "title": "Bundle Moving to Review",
+                "updated_at": "{{DYNAMIC_TIMESTAMP}}"
+            }
+            """
+
+    Scenario: PUT /bundles/{id} with state transition from APPROVED to PUBLISHED
+        Given I am an admin user
+        And I set the header "If-Match" to "etag-bundle-3"
+        When I PUT "/bundles/bundle-3"
+            """
+            {
+                "bundle_type": "MANUAL",
+                "preview_teams": [
+                    {
+                        "id": "567j908h-98df-11ec-b909-0242ac120002"
+                    }
+                ],
+                "state": "PUBLISHED",
+                "title": "Published Bundle",
+                "managed_by": "DATA-ADMIN"
+            }
+            """
+        Then the HTTP status code should be "200"
+        And the response should contain with dynamic timestamp:
+            """
+            {
+                "bundle_type": "MANUAL",
+                "created_at": "2025-04-05T13:40:00Z",
+                "created_by": {
+                    "email": "publisher@ons.gov.uk"
+                },
+                "id": "bundle-3",
+                "last_updated_by": {
+                    "email": "janedoe@example.com"
+                },
+                "managed_by": "DATA-ADMIN",
+                "preview_teams": [
+                    {
+                        "id": "567j908h-98df-11ec-b909-0242ac120002"
+                    }
+                ],
+                "state": "PUBLISHED",
+                "title": "Published Bundle",
+                "updated_at": "{{DYNAMIC_TIMESTAMP}}"
+            }
+            """
+
+    Scenario: PUT /bundles/{id} without If-Match header returns 409
+        Given I am an admin user
+        When I PUT "/bundles/bundle-1"
+            """
+            {
+                "bundle_type": "MANUAL",
+                "preview_teams": [
+                    {
+                        "id": "890m231k-98df-11ec-b909-0242ac120002"
+                    }
+                ],
+                "title": "Updated Title",
+                "managed_by": "DATA-ADMIN"
+            }
+            """
+        Then I should receive the following JSON response with status "409":
+            """
+            {
+                "errors": [
+                    {
+                        "code": "conflict",
+                        "description": "Change rejected due to a conflict with the current resource state. A common cause is attempted to change a bundle that is already locked pending publication or has already been published."
+                    }
+                ]
+            }
+            """
+
+    Scenario: PUT /bundles/{id} with mismatched ETag returns 409
+        Given I am an admin user
+        And I set the header "If-Match" to "wrong-etag"
+        When I PUT "/bundles/bundle-1"
+            """
+            {
+                "bundle_type": "MANUAL",
+                "preview_teams": [
+                    {
+                        "id": "890m231k-98df-11ec-b909-0242ac120002"
+                    }
+                ],
+                "title": "Updated Title",
+                "managed_by": "DATA-ADMIN"
+            }
+            """
+        Then I should receive the following JSON response with status "409":
+            """
+            {
+                "errors": [
+                    {
+                        "code": "conflict",
+                        "description": "Change rejected due to a conflict with the current resource state. A common cause is attempted to change a bundle that is already locked pending publication or has already been published."
+                    }
+                ]
+            }
+            """
+
+    Scenario: PUT /bundles/{id} with invalid bundle data returns 400
+        Given I am an admin user
+        And I set the header "If-Match" to "etag-bundle-1"
+        When I PUT "/bundles/bundle-1"
+            """
+            {
+                "bundle_type": "INVALID_TYPE",
+                "preview_teams": [],
+                "state": "INVALID_STATE",
+                "title": "",
+                "managed_by": "INVALID_MANAGER"
+            }
+            """
+        Then I should receive the following JSON response with status "400":
+            """
+            {
+                "errors": [
+                    {
+                        "code": "invalid_parameters",
+                        "description": "Unable to process request due to a malformed or invalid request body or query parameter",
+                        "source": {
+                            "field": "/bundle_type"
+                        }
+                    },
+                    {
+                        "code": "missing_parameters",
+                        "description": "Unable to process request due to missing required parameters in the request body or query parameters",
+                        "source": {
+                            "field": "/preview_teams"
+                        }
+                    },
+                    {
+                        "code": "invalid_parameters",
+                        "description": "Unable to process request due to a malformed or invalid request body or query parameter",
+                        "source": {
+                            "field": "/state"
+                        }
+                    },
+                    {
+                        "code": "missing_parameters",
+                        "description": "Unable to process request due to missing required parameters in the request body or query parameters",
+                        "source": {
+                            "field": "/title"
+                        }
+                    },
+                    {
+                        "code": "invalid_parameters",
+                        "description": "Unable to process request due to a malformed or invalid request body or query parameter",
+                        "source": {
+                            "field": "/managed_by"
+                        }
+                    }
+                ]
+            }
+            """
+
+    Scenario: PUT /bundles/{id} with duplicate title returns 400
+        Given I am an admin user
+        And I set the header "If-Match" to "etag-bundle-1"
+        When I PUT "/bundles/bundle-1"
+            """
+            {
+                "bundle_type": "MANUAL",
+                "preview_teams": [
+                    {
+                        "id": "890m231k-98df-11ec-b909-0242ac120002"
+                    }
+                ],
+                "state": "DRAFT",
+                "title": "Scheduled Bundle",
+                "managed_by": "DATA-ADMIN"
+            }
+            """
+        Then I should receive the following JSON response with status "400":
+            """
+            {
+                "errors": [
+                    {
+                        "code": "ErrInvalidParameters",
+                        "description": "Unable to process request due to a malformed or invalid request body or query parameter",
+                        "source": {
+                            "field": "/title"
+                        }
+                    }
+                ]
+            }
+            """
+
+
+  Scenario: PUT /bundles/{id} with SCHEDULED type missing scheduled_at returns 400
+        Given I am an admin user
+        And I set the header "If-Match" to "etag-bundle-1"
+        When I PUT "/bundles/bundle-1"
+            """
+            {
+                "bundle_type": "SCHEDULED",
+                "preview_teams": [
+                    {
+                        "id": "890m231k-98df-11ec-b909-0242ac120002"
+                    }
+                ],
+                "state": "DRAFT",
+                "title": "Missing Scheduled Date",
+                "managed_by": "DATA-ADMIN"
+            }
+            """
+        Then I should receive the following JSON response with status "400":
+            """
+            {
+                "errors": [
+                    {
+                        "code": "ErrInvalidParameters",
+                        "description": "Unable to process request due to a malformed or invalid request body or query parameter",
+                        "source": {
+                            "field": "/scheduled_at"
+                        }
+                    }
+                ]
+            }
+            """
+
+   Scenario: PUT /bundles/{id} with MANUAL type and scheduled_at returns 400
+        Given I am an admin user
+        And I set the header "If-Match" to "etag-bundle-1"
+        When I PUT "/bundles/bundle-1"
+            """
+            {
+                "bundle_type": "MANUAL",
+                "preview_teams": [
+                    {
+                        "id": "890m231k-98df-11ec-b909-0242ac120002"
+                    }
+                ],
+                "state": "DRAFT",
+                "scheduled_at": "2025-06-01T10:00:00Z",
+                "title": "Manual with Scheduled Date",
+                "managed_by": "DATA-ADMIN"
+            }
+            """
+        Then I should receive the following JSON response with status "400":
+            """
+            {
+                "errors": [
+                    {
+                        "code": "ErrInvalidParameters",
+                        "description": "Unable to process request due to a malformed or invalid request body or query parameter",
+                        "source": {
+                            "field": "/scheduled_at"
+                        }
+                    }
+                ]
+            }
+            """
+
+   Scenario: PUT /bundles/{id} with past scheduled_at returns 400
+        Given I am an admin user
+        And I set the header "If-Match" to "etag-bundle-1"
+        When I PUT "/bundles/bundle-1"
+            """
+            {
+                "bundle_type": "SCHEDULED",
+                "preview_teams": [
+                    {
+                        "id": "890m231k-98df-11ec-b909-0242ac120002"
+                    }
+                ],
+                "state": "DRAFT",
+                "scheduled_at": "2020-01-01T10:00:00Z",
+                "title": "Past Scheduled Date",
+                "managed_by": "DATA-ADMIN"
+            }
+            """
+        Then I should receive the following JSON response with status "400":
+            """
+            {
+                "errors": [
+                    {
+                        "code": "ErrInvalidParameters",
+                        "description": "Unable to process request due to a malformed or invalid request body or query parameter",
+                        "source": {
+                            "field": "/scheduled_at"
+                        }
+                    }
+                ]
+            }
+            """
+
+    Scenario: PUT /bundles/{id} with invalid state transition returns 400
+        Given I am an admin user
+        And I set the header "If-Match" to "etag-bundle-1"
+        When I PUT "/bundles/bundle-1"
+            """
+            {
+                "bundle_type": "MANUAL",
+                "preview_teams": [
+                    {
+                        "id": "890m231k-98df-11ec-b909-0242ac120002"
+                    }
+                ],
+                "state": "PUBLISHED",
+                "title": "Invalid Transition",
+                "managed_by": "DATA-ADMIN"
+            }
+            """
+        Then I should receive the following JSON response with status "400":
+            """
+            {
+                "errors": [
+                    {
+                        "code": "ErrInvalidParameters",
+                        "description": "Unable to process request due to a malformed or invalid request body or query parameter",
+                        "source": {
+                            "field": "/state"
+                        }
+                    }
+                ]
+            }
+            """
+
+    Scenario: PUT /bundles/{id} for non-existent bundle returns 404
+        Given I am an admin user
+        And I set the header "If-Match" to "some-etag"
+        When I PUT "/bundles/bundle-missing"
+            """
+            {
+                "bundle_type": "MANUAL",
+                "preview_teams": [
+                    {
+                        "id": "890m231k-98df-11ec-b909-0242ac120002"
+                    }
+                ],
+                "title": "Missing Bundle",
+                "managed_by": "DATA-ADMIN"
+            }
+            """
+        Then I should receive the following JSON response with status "404":
+            """
+            {
+                "errors": [
+                    {
+                        "code": "NotFound",
+                        "description": "The requested resource does not exist"
+                    }
+                ]
+            }
+            """
+
+    Scenario: PUT /bundles/{id} without authentication returns 401
+        Given I am not authenticated
+        And I set the header "If-Match" to "etag-bundle-1"
+        When I PUT "/bundles/bundle-1"
+            """
+            {
+                "bundle_type": "MANUAL",
+                "preview_teams": [
+                    {
+                        "id": "890m231k-98df-11ec-b909-0242ac120002"
+                    }
+                ],
+                "title": "Updated Title",
+                "managed_by": "DATA-ADMIN"
+            }
+            """
+        Then the HTTP status code should be "401"
+        And the response body should be empty

--- a/features/steps/bundle_component.go
+++ b/features/steps/bundle_component.go
@@ -26,6 +26,10 @@ import (
 	"github.com/ONSdigital/log.go/v2/log"
 )
 
+const (
+	datasetNotFound = "dataset-not-found"
+)
+
 var mockDatasetVersions = []*datasetAPIModels.Version{
 	{ID: "1"},
 	{ID: "2"},
@@ -188,7 +192,7 @@ func (c *BundleComponent) DoGetMongoDB(context.Context, config.MongoConfig) (sto
 func (c *BundleComponent) DoGetDatasetAPIClient(datasetAPIURL string) datasetAPISDK.Clienter {
 	datasetAPIClient := &datasetAPISDKMock.ClienterMock{
 		GetVersionFunc: func(ctx context.Context, headers datasetAPISDK.Headers, datasetID, editionID string, versionID string) (datasetAPIModels.Version, error) {
-			if datasetID == "dataset-not-found" {
+			if datasetID == datasetNotFound {
 				return datasetAPIModels.Version{}, errors.New("dataset not found")
 			}
 			if editionID == "edition-not-found" {

--- a/mongo/bundle_contents_store.go
+++ b/mongo/bundle_contents_store.go
@@ -71,6 +71,22 @@ func (m *Mongo) CheckContentItemExistsByDatasetEditionVersion(ctx context.Contex
 	return count > 0, nil
 }
 
+// GetContentItemsByBundleID retrieves all content items for a specific bundle
+func (m *Mongo) GetContentItemsByBundleID(ctx context.Context, bundleID string) ([]*models.ContentItem, error) {
+	var results []*models.ContentItem
+
+	filter := bson.M{"bundle_id": bundleID}
+
+	_, err := m.Connection.Collection(m.ActualCollectionName(config.BundleContentsCollection)).
+		Find(ctx, filter, &results)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return results, nil
+}
+
 // GetBundleContentsForBundle retrieves all ContentItems for the specified bundle
 func (m *Mongo) GetBundleContentsForBundle(ctx context.Context, bundleID string) (*[]models.ContentItem, error) {
 	filter := bson.M{
@@ -84,6 +100,23 @@ func (m *Mongo) GetBundleContentsForBundle(ctx context.Context, bundleID string)
 	}
 
 	return &contents, nil
+}
+
+// UpdateContentItemDatasetInfo updates a content item with dataset title and state
+func (m *Mongo) UpdateContentItemDatasetInfo(ctx context.Context, contentItemID, title, state string) error {
+	filter := bson.M{"id": contentItemID}
+
+	updateData := bson.M{
+		"$set": bson.M{
+			"metadata.title": title,
+			"state":          state,
+		},
+	}
+
+	_, err := m.Connection.Collection(m.ActualCollectionName(config.BundleContentsCollection)).
+		UpdateOne(ctx, filter, updateData)
+
+	return err
 }
 
 // DeleteContentItem removes a content item by its ID

--- a/mongo/bundle_store.go
+++ b/mongo/bundle_store.go
@@ -72,7 +72,6 @@ func buildGetBundleQuery(bundleID string) bson.M {
 func (m *Mongo) CreateBundle(ctx context.Context, bundle *models.Bundle) error {
 	now := time.Now()
 	bundle.CreatedAt = &now
-	bundle.UpdatedAt = &now
 	collectionName := m.ActualCollectionName(config.BundlesCollection)
 
 	_, err := m.Connection.Collection(collectionName).InsertOne(ctx, bundle)
@@ -180,6 +179,21 @@ func (m *Mongo) CheckBundleExists(ctx context.Context, bundleID string) (bool, e
 		return false, err
 	}
 	return count > 0, nil
+}
+
+func (m *Mongo) CheckBundleExistsByTitleUpdate(ctx context.Context, title, excludeID string) (bool, error) {
+	filter := bson.M{
+		"title": title,
+		"id":    bson.M{"$ne": excludeID},
+	}
+
+	count, err := m.Connection.Collection(m.ActualCollectionName(config.BundlesCollection)).Count(ctx, filter)
+	if err != nil {
+		return false, err
+	}
+
+	return count > 0, nil
+
 }
 
 // CheckBundleExistsByTitle checks if a bundle exists by its title

--- a/mongo/bundle_store.go
+++ b/mongo/bundle_store.go
@@ -193,7 +193,6 @@ func (m *Mongo) CheckBundleExistsByTitleUpdate(ctx context.Context, title, exclu
 	}
 
 	return count > 0, nil
-
 }
 
 // CheckBundleExistsByTitle checks if a bundle exists by its title

--- a/mongo/bundle_store_test.go
+++ b/mongo/bundle_store_test.go
@@ -6,15 +6,14 @@ import (
 	"time"
 
 	"github.com/ONSdigital/dis-bundle-api/apierrors"
-	"github.com/ONSdigital/dis-bundle-api/config"
 	"github.com/ONSdigital/dis-bundle-api/filters"
 	"github.com/ONSdigital/dis-bundle-api/models"
 	. "github.com/smartystreets/goconvey/convey"
 	"go.mongodb.org/mongo-driver/bson"
 )
 
-func setupBundleTestData(ctx context.Context, mongodb *Mongo) ([]*models.Bundle, error) {
-	if err := mongodb.Connection.DropDatabase(ctx); err != nil {
+func setupBundleTestData(ctx context.Context, mongo *Mongo) ([]*models.Bundle, error) {
+	if err := mongo.Connection.DropDatabase(ctx); err != nil {
 		return nil, err
 	}
 
@@ -63,8 +62,8 @@ func setupBundleTestData(ctx context.Context, mongodb *Mongo) ([]*models.Bundle,
 		},
 	}
 
-	for _, bundle := range bundles {
-		if _, err := mongodb.Connection.Collection(mongodb.ActualCollectionName(config.BundlesCollection)).InsertOne(ctx, bundle); err != nil {
+	for _, b := range bundles {
+		if err := mongo.CreateBundle(ctx, b); err != nil {
 			return nil, err
 		}
 	}
@@ -311,8 +310,6 @@ func TestCreateBundle_Success(t *testing.T) {
 				So(returnedBundle.Title, ShouldEqual, "New Bundle")
 				So(returnedBundle.ManagedBy, ShouldEqual, models.ManagedByWagtail)
 				So(returnedBundle.ETag, ShouldEqual, "some-etag")
-				So(returnedBundle.CreatedAt, ShouldNotBeNil)
-				So(returnedBundle.UpdatedAt, ShouldNotBeNil)
 			})
 		})
 	})

--- a/store/datastore.go
+++ b/store/datastore.go
@@ -41,6 +41,9 @@ type dataMongoDB interface {
 	// Events
 	ListBundleContents(ctx context.Context, bundleID string, offset, limit int) ([]*models.ContentItem, int, error)
 	CreateBundleEvent(ctx context.Context, event *models.Event) error
+	CheckBundleExistsByTitleUpdate(ctx context.Context, title, excludeID string) (bool, error)
+	GetContentItemsByBundleID(ctx context.Context, bundleID string) ([]*models.ContentItem, error)
+	UpdateContentItemDatasetInfo(ctx context.Context, contentItemID, title, state string) error
 
 	// Other
 	Checker(ctx context.Context, state *healthcheck.CheckState) error
@@ -110,6 +113,17 @@ func (ds *Datastore) CreateBundleEvent(ctx context.Context, event *models.Event)
 	return ds.Backend.CreateBundleEvent(ctx, event)
 }
 
+func (ds *Datastore) CheckBundleExistsByTitleUpdate(ctx context.Context, title, excludeID string) (bool, error) {
+	return ds.Backend.CheckBundleExistsByTitleUpdate(ctx, title, excludeID)
+}
+
+func (ds *Datastore) GetContentItemsByBundleID(ctx context.Context, bundleID string) ([]*models.ContentItem, error) {
+	return ds.Backend.GetContentItemsByBundleID(ctx, bundleID)
+}
+
+func (ds *Datastore) UpdateContentItemDatasetInfo(ctx context.Context, contentItemID, title, state string) error {
+	return ds.Backend.UpdateContentItemDatasetInfo(ctx, contentItemID, title, state)
+}
 func (ds *Datastore) GetBundleContentsForBundle(ctx context.Context, bundleID string) (*[]models.ContentItem, error) {
 	return ds.Backend.GetBundleContentsForBundle(ctx, bundleID)
 }

--- a/store/datastoretest/datastore.go
+++ b/store/datastoretest/datastore.go
@@ -32,6 +32,9 @@ var _ store.Storer = &StorerMock{}
 //			CheckBundleExistsByTitleFunc: func(ctx context.Context, title string) (bool, error) {
 //				panic("mock out the CheckBundleExistsByTitle method")
 //			},
+//			CheckBundleExistsByTitleUpdateFunc: func(ctx context.Context, title string, excludeID string) (bool, error) {
+//				panic("mock out the CheckBundleExistsByTitleUpdate method")
+//			},
 //			CheckContentItemExistsByDatasetEditionVersionFunc: func(ctx context.Context, datasetID string, editionID string, versionID int) (bool, error) {
 //				panic("mock out the CheckContentItemExistsByDatasetEditionVersion method")
 //			},
@@ -62,6 +65,9 @@ var _ store.Storer = &StorerMock{}
 //			GetContentItemByBundleIDAndContentItemIDFunc: func(ctx context.Context, bundleID string, contentItemID string) (*models.ContentItem, error) {
 //				panic("mock out the GetContentItemByBundleIDAndContentItemID method")
 //			},
+//			GetContentItemsByBundleIDFunc: func(ctx context.Context, bundleID string) ([]*models.ContentItem, error) {
+//				panic("mock out the GetContentItemsByBundleID method")
+//			},
 //			ListBundleContentsFunc: func(ctx context.Context, bundleID string, offset int, limit int) ([]*models.ContentItem, int, error) {
 //				panic("mock out the ListBundleContents method")
 //			},
@@ -76,6 +82,9 @@ var _ store.Storer = &StorerMock{}
 //			},
 //			UpdateBundleETagFunc: func(ctx context.Context, bundleID string, email string) (*models.Bundle, error) {
 //				panic("mock out the UpdateBundleETag method")
+//			},
+//			UpdateContentItemDatasetInfoFunc: func(ctx context.Context, contentItemID string, title string, state string) error {
+//				panic("mock out the UpdateContentItemDatasetInfo method")
 //			},
 //			UpdateContentItemStateFunc: func(ctx context.Context, contentItemID string, state string) error {
 //				panic("mock out the UpdateContentItemState method")
@@ -95,6 +104,9 @@ type StorerMock struct {
 
 	// CheckBundleExistsByTitleFunc mocks the CheckBundleExistsByTitle method.
 	CheckBundleExistsByTitleFunc func(ctx context.Context, title string) (bool, error)
+
+	// CheckBundleExistsByTitleUpdateFunc mocks the CheckBundleExistsByTitleUpdate method.
+	CheckBundleExistsByTitleUpdateFunc func(ctx context.Context, title string, excludeID string) (bool, error)
 
 	// CheckContentItemExistsByDatasetEditionVersionFunc mocks the CheckContentItemExistsByDatasetEditionVersion method.
 	CheckContentItemExistsByDatasetEditionVersionFunc func(ctx context.Context, datasetID string, editionID string, versionID int) (bool, error)
@@ -126,6 +138,9 @@ type StorerMock struct {
 	// GetContentItemByBundleIDAndContentItemIDFunc mocks the GetContentItemByBundleIDAndContentItemID method.
 	GetContentItemByBundleIDAndContentItemIDFunc func(ctx context.Context, bundleID string, contentItemID string) (*models.ContentItem, error)
 
+	// GetContentItemsByBundleIDFunc mocks the GetContentItemsByBundleID method.
+	GetContentItemsByBundleIDFunc func(ctx context.Context, bundleID string) ([]*models.ContentItem, error)
+
 	// ListBundleContentsFunc mocks the ListBundleContents method.
 	ListBundleContentsFunc func(ctx context.Context, bundleID string, offset int, limit int) ([]*models.ContentItem, int, error)
 
@@ -140,6 +155,9 @@ type StorerMock struct {
 
 	// UpdateBundleETagFunc mocks the UpdateBundleETag method.
 	UpdateBundleETagFunc func(ctx context.Context, bundleID string, email string) (*models.Bundle, error)
+
+	// UpdateContentItemDatasetInfoFunc mocks the UpdateContentItemDatasetInfo method.
+	UpdateContentItemDatasetInfoFunc func(ctx context.Context, contentItemID string, title string, state string) error
 
 	// UpdateContentItemStateFunc mocks the UpdateContentItemState method.
 	UpdateContentItemStateFunc func(ctx context.Context, contentItemID string, state string) error
@@ -166,6 +184,15 @@ type StorerMock struct {
 			Ctx context.Context
 			// Title is the title argument value.
 			Title string
+		}
+		// CheckBundleExistsByTitleUpdate holds details about calls to the CheckBundleExistsByTitleUpdate method.
+		CheckBundleExistsByTitleUpdate []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// Title is the title argument value.
+			Title string
+			// ExcludeID is the excludeID argument value.
+			ExcludeID string
 		}
 		// CheckContentItemExistsByDatasetEditionVersion holds details about calls to the CheckContentItemExistsByDatasetEditionVersion method.
 		CheckContentItemExistsByDatasetEditionVersion []struct {
@@ -241,6 +268,13 @@ type StorerMock struct {
 			// ContentItemID is the contentItemID argument value.
 			ContentItemID string
 		}
+		// GetContentItemsByBundleID holds details about calls to the GetContentItemsByBundleID method.
+		GetContentItemsByBundleID []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// BundleID is the bundleID argument value.
+			BundleID string
+		}
 		// ListBundleContents holds details about calls to the ListBundleContents method.
 		ListBundleContents []struct {
 			// Ctx is the ctx argument value.
@@ -296,6 +330,17 @@ type StorerMock struct {
 			// Email is the email argument value.
 			Email string
 		}
+		// UpdateContentItemDatasetInfo holds details about calls to the UpdateContentItemDatasetInfo method.
+		UpdateContentItemDatasetInfo []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// ContentItemID is the contentItemID argument value.
+			ContentItemID string
+			// Title is the title argument value.
+			Title string
+			// State is the state argument value.
+			State string
+		}
 		// UpdateContentItemState holds details about calls to the UpdateContentItemState method.
 		UpdateContentItemState []struct {
 			// Ctx is the ctx argument value.
@@ -309,6 +354,7 @@ type StorerMock struct {
 	lockCheckAllBundleContentsAreApproved             sync.RWMutex
 	lockCheckBundleExists                             sync.RWMutex
 	lockCheckBundleExistsByTitle                      sync.RWMutex
+	lockCheckBundleExistsByTitleUpdate                sync.RWMutex
 	lockCheckContentItemExistsByDatasetEditionVersion sync.RWMutex
 	lockChecker                                       sync.RWMutex
 	lockClose                                         sync.RWMutex
@@ -319,11 +365,13 @@ type StorerMock struct {
 	lockGetBundle                                     sync.RWMutex
 	lockGetBundleContentsForBundle                    sync.RWMutex
 	lockGetContentItemByBundleIDAndContentItemID      sync.RWMutex
+	lockGetContentItemsByBundleID                     sync.RWMutex
 	lockListBundleContents                            sync.RWMutex
 	lockListBundleEvents                              sync.RWMutex
 	lockListBundles                                   sync.RWMutex
 	lockUpdateBundle                                  sync.RWMutex
 	lockUpdateBundleETag                              sync.RWMutex
+	lockUpdateContentItemDatasetInfo                  sync.RWMutex
 	lockUpdateContentItemState                        sync.RWMutex
 }
 
@@ -432,6 +480,46 @@ func (mock *StorerMock) CheckBundleExistsByTitleCalls() []struct {
 	mock.lockCheckBundleExistsByTitle.RLock()
 	calls = mock.calls.CheckBundleExistsByTitle
 	mock.lockCheckBundleExistsByTitle.RUnlock()
+	return calls
+}
+
+// CheckBundleExistsByTitleUpdate calls CheckBundleExistsByTitleUpdateFunc.
+func (mock *StorerMock) CheckBundleExistsByTitleUpdate(ctx context.Context, title string, excludeID string) (bool, error) {
+	if mock.CheckBundleExistsByTitleUpdateFunc == nil {
+		panic("StorerMock.CheckBundleExistsByTitleUpdateFunc: method is nil but Storer.CheckBundleExistsByTitleUpdate was just called")
+	}
+	callInfo := struct {
+		Ctx       context.Context
+		Title     string
+		ExcludeID string
+	}{
+		Ctx:       ctx,
+		Title:     title,
+		ExcludeID: excludeID,
+	}
+	mock.lockCheckBundleExistsByTitleUpdate.Lock()
+	mock.calls.CheckBundleExistsByTitleUpdate = append(mock.calls.CheckBundleExistsByTitleUpdate, callInfo)
+	mock.lockCheckBundleExistsByTitleUpdate.Unlock()
+	return mock.CheckBundleExistsByTitleUpdateFunc(ctx, title, excludeID)
+}
+
+// CheckBundleExistsByTitleUpdateCalls gets all the calls that were made to CheckBundleExistsByTitleUpdate.
+// Check the length with:
+//
+//	len(mockedStorer.CheckBundleExistsByTitleUpdateCalls())
+func (mock *StorerMock) CheckBundleExistsByTitleUpdateCalls() []struct {
+	Ctx       context.Context
+	Title     string
+	ExcludeID string
+} {
+	var calls []struct {
+		Ctx       context.Context
+		Title     string
+		ExcludeID string
+	}
+	mock.lockCheckBundleExistsByTitleUpdate.RLock()
+	calls = mock.calls.CheckBundleExistsByTitleUpdate
+	mock.lockCheckBundleExistsByTitleUpdate.RUnlock()
 	return calls
 }
 
@@ -803,6 +891,42 @@ func (mock *StorerMock) GetContentItemByBundleIDAndContentItemIDCalls() []struct
 	return calls
 }
 
+// GetContentItemsByBundleID calls GetContentItemsByBundleIDFunc.
+func (mock *StorerMock) GetContentItemsByBundleID(ctx context.Context, bundleID string) ([]*models.ContentItem, error) {
+	if mock.GetContentItemsByBundleIDFunc == nil {
+		panic("StorerMock.GetContentItemsByBundleIDFunc: method is nil but Storer.GetContentItemsByBundleID was just called")
+	}
+	callInfo := struct {
+		Ctx      context.Context
+		BundleID string
+	}{
+		Ctx:      ctx,
+		BundleID: bundleID,
+	}
+	mock.lockGetContentItemsByBundleID.Lock()
+	mock.calls.GetContentItemsByBundleID = append(mock.calls.GetContentItemsByBundleID, callInfo)
+	mock.lockGetContentItemsByBundleID.Unlock()
+	return mock.GetContentItemsByBundleIDFunc(ctx, bundleID)
+}
+
+// GetContentItemsByBundleIDCalls gets all the calls that were made to GetContentItemsByBundleID.
+// Check the length with:
+//
+//	len(mockedStorer.GetContentItemsByBundleIDCalls())
+func (mock *StorerMock) GetContentItemsByBundleIDCalls() []struct {
+	Ctx      context.Context
+	BundleID string
+} {
+	var calls []struct {
+		Ctx      context.Context
+		BundleID string
+	}
+	mock.lockGetContentItemsByBundleID.RLock()
+	calls = mock.calls.GetContentItemsByBundleID
+	mock.lockGetContentItemsByBundleID.RUnlock()
+	return calls
+}
+
 // ListBundleContents calls ListBundleContentsFunc.
 func (mock *StorerMock) ListBundleContents(ctx context.Context, bundleID string, offset int, limit int) ([]*models.ContentItem, int, error) {
 	if mock.ListBundleContentsFunc == nil {
@@ -1020,6 +1144,50 @@ func (mock *StorerMock) UpdateBundleETagCalls() []struct {
 	mock.lockUpdateBundleETag.RLock()
 	calls = mock.calls.UpdateBundleETag
 	mock.lockUpdateBundleETag.RUnlock()
+	return calls
+}
+
+// UpdateContentItemDatasetInfo calls UpdateContentItemDatasetInfoFunc.
+func (mock *StorerMock) UpdateContentItemDatasetInfo(ctx context.Context, contentItemID string, title string, state string) error {
+	if mock.UpdateContentItemDatasetInfoFunc == nil {
+		panic("StorerMock.UpdateContentItemDatasetInfoFunc: method is nil but Storer.UpdateContentItemDatasetInfo was just called")
+	}
+	callInfo := struct {
+		Ctx           context.Context
+		ContentItemID string
+		Title         string
+		State         string
+	}{
+		Ctx:           ctx,
+		ContentItemID: contentItemID,
+		Title:         title,
+		State:         state,
+	}
+	mock.lockUpdateContentItemDatasetInfo.Lock()
+	mock.calls.UpdateContentItemDatasetInfo = append(mock.calls.UpdateContentItemDatasetInfo, callInfo)
+	mock.lockUpdateContentItemDatasetInfo.Unlock()
+	return mock.UpdateContentItemDatasetInfoFunc(ctx, contentItemID, title, state)
+}
+
+// UpdateContentItemDatasetInfoCalls gets all the calls that were made to UpdateContentItemDatasetInfo.
+// Check the length with:
+//
+//	len(mockedStorer.UpdateContentItemDatasetInfoCalls())
+func (mock *StorerMock) UpdateContentItemDatasetInfoCalls() []struct {
+	Ctx           context.Context
+	ContentItemID string
+	Title         string
+	State         string
+} {
+	var calls []struct {
+		Ctx           context.Context
+		ContentItemID string
+		Title         string
+		State         string
+	}
+	mock.lockUpdateContentItemDatasetInfo.RLock()
+	calls = mock.calls.UpdateContentItemDatasetInfo
+	mock.lockUpdateContentItemDatasetInfo.RUnlock()
 	return calls
 }
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -66,3 +66,26 @@ func GetRequestBody[T any](r *http.Request) (*T, error) {
 
 	return &requestBody, nil
 }
+
+func MapErrorCodeToStatus(code *models.Code) int {
+	if code == nil {
+		return http.StatusInternalServerError
+	}
+
+	switch *code {
+	case models.CodeNotFound, models.NotFound:
+		return http.StatusNotFound
+	case models.CodeBadRequest, models.ErrInvalidParameters, models.CodeInvalidParameters, models.CodeMissingParameters:
+		return http.StatusBadRequest
+	case models.CodeUnauthorized, models.Unauthorised:
+		return http.StatusUnauthorized
+	case models.CodeForbidden:
+		return http.StatusForbidden
+	case models.CodeConflict:
+		return http.StatusConflict
+	case models.CodeInternalServerError, models.InternalError, models.JSONMarshalError, models.JSONUnmarshalError, models.WriteResponseError:
+		return http.StatusInternalServerError
+	default:
+		return http.StatusInternalServerError
+	}
+}


### PR DESCRIPTION
### What

Create PUT `/bundles/{bundle-id}` endpoint
Jira - https://jira.ons.gov.uk/browse/DIS-2947

### How to review

Manually add an `e_tag` value to the `bundle-1` bundle record in the `bundles.json` file in `dataset-catalogue` stack

Add the same value to the `If-Match` header to your request headers in Postman

Make a PUT request to -

`localhost:29800/bundles/bundle-1` with the following request body - 

```
{
  "bundle_type": "MANUAL",
  "preview_teams": [
    {
      "id": "a46e362c-98de-11ec-b909-0242ac120002"
    }
  ],
  "state": "IN_REVIEW",
  "title": "Bundle Moving to Review",
  "managed_by": "DATA-ADMIN"
}
```

You will need to make each request sequentially in terms of the state transition, so DRAFT > IN_REVIEW > APPROVED > PUBLISHED, otherwise an error will be returned

Every time a PUT request is made a new etag is returned in the response header, so you will need to use this etag as the `If-Match` value for the next request

When each request is made, check the local `bundle-events` database for `bundle-1` to ensure that the event records are being created for each PUT request

Once the final PUT request is made from APPROVED > PUBLISHED, check the `bundle-contents` db to confirm that the content item for `bundle-1` has been updated with correct `state` and `title` data from the related dataset

Confirm that all acceptance criteria is met

Confirm changes make sense and tests pass


### Who can review

Anyone