### PR TITLE
Feature/delete bundle endpoint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -92,6 +92,12 @@ issues:
     - path: api/contents_test.go
       linters:
         - goconst
+    - path: api/bundles_test.go
+      linters:
+        - goconst
+    - path: application/application_test.go
+      linters:
+        - goconst
     - path: mongo/bundle_contents_store_test.go
       linters:
         - goconst

--- a/api/api.go
+++ b/api/api.go
@@ -43,6 +43,10 @@ func Setup(ctx context.Context, cfg *config.Config, router *mux.Router, store *s
 		"/bundles/{bundle-id}",
 		authMiddleware.Require("bundles:read", api.getBundle),
 	)
+	api.delete(
+		"/bundles/{bundle-id}",
+		authMiddleware.Require("bundles:delete", api.deleteBundle),
+	)
 	api.get(
 		"/bundle-events",
 		authMiddleware.Require("bundles:read", paginator.Paginate(api.getBundleEvents)),

--- a/api/api.go
+++ b/api/api.go
@@ -36,17 +36,9 @@ func Setup(ctx context.Context, cfg *config.Config, router *mux.Router, store *s
 		"/bundles",
 		authMiddleware.Require("bundles:read", pagination.Paginate(paginator, api.getBundles)),
 	)
-	api.post(
-		"/bundles",
-		authMiddleware.Require("bundles:create", api.createBundle),
-	)
 	api.get(
 		"/bundles/{bundle-id}",
 		authMiddleware.Require("bundles:read", api.getBundle),
-	)
-	api.delete(
-		"/bundles/{bundle-id}",
-		authMiddleware.Require("bundles:delete", api.deleteBundle),
 	)
 	api.get(
 		"/bundle-events",
@@ -59,18 +51,27 @@ func Setup(ctx context.Context, cfg *config.Config, router *mux.Router, store *s
 
 	// post
 	api.post(
+		"/bundles",
+		authMiddleware.Require("bundles:create", api.createBundle),
+	)
+	api.post(
 		"/bundles/{bundle-id}/contents",
 		authMiddleware.Require("bundles:create", api.postBundleContents),
-	)
-
-	api.delete(
-		"/bundles/{bundle-id}/contents/{content-id}",
-		authMiddleware.Require("bundles:delete", api.deleteContentItem),
 	)
 
 	// put
 	api.put("/bundles/{bundle-id}/state",
 		authMiddleware.Require("bundles:update", api.putBundleState))
+
+	// delete
+	api.delete(
+		"/bundles/{bundle-id}",
+		authMiddleware.Require("bundles:delete", api.deleteBundle),
+	)
+	api.delete(
+		"/bundles/{bundle-id}/contents/{content-id}",
+		authMiddleware.Require("bundles:delete", api.deleteContentItem),
+	)
 
 	return api
 }

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -18,6 +18,7 @@ func TestSetup(t *testing.T) {
 			So(hasRoute(api.Router, "/bundles", "GET"), ShouldBeTrue)
 			So(hasRoute(api.Router, "/bundles", "POST"), ShouldBeTrue)
 			So(hasRoute(api.Router, "/bundles/{bundle-id}", "GET"), ShouldBeTrue)
+			So(hasRoute(api.Router, "/bundles/{bundle-id}", "DELETE"), ShouldBeTrue)
 			So(hasRoute(api.Router, "/bundles/{bundle-id}/contents", "POST"), ShouldBeTrue)
 			So(hasRoute(api.Router, "/bundles/{bundle-id}/contents/{content-id}", "DELETE"), ShouldBeTrue)
 			So(hasRoute(api.Router, "/bundle-events", "GET"), ShouldBeTrue)

--- a/api/bundles.go
+++ b/api/bundles.go
@@ -16,6 +16,11 @@ import (
 	"github.com/gorilla/mux"
 )
 
+const (
+	BundleIDPathParam  = "bundle-id"
+	ContentIDPathParam = "content-id"
+)
+
 func (api *BundleAPI) getBundles(w http.ResponseWriter, r *http.Request, limit, offset int) (successResult *models.PaginationSuccessResult[models.Bundle], errorResult *models.ErrorResult[models.Error]) {
 	ctx := r.Context()
 
@@ -48,8 +53,8 @@ func (api *BundleAPI) getBundles(w http.ResponseWriter, r *http.Request, limit, 
 func (api *BundleAPI) getBundle(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	vars := mux.Vars(r)
-	bundleID := vars["bundle-id"]
-	logData := log.Data{"bundle-id": bundleID}
+	bundleID := vars[BundleIDPathParam]
+	logData := log.Data{BundleIDPathParam: bundleID}
 
 	bundle, err := api.stateMachineBundleAPI.GetBundle(ctx, bundleID)
 	if err != nil {
@@ -236,13 +241,13 @@ func (api *BundleAPI) createBundle(w http.ResponseWriter, r *http.Request) {
 func (api *BundleAPI) deleteBundle(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	vars := mux.Vars(r)
-	bundleID := vars["bundle-id"]
-	logData := log.Data{"bundle-id": bundleID}
+	bundleID := vars[BundleIDPathParam]
+	logData := log.Data{BundleIDPathParam: bundleID}
 
 	var entityData *permSDK.EntityData
 	entityData, err := api.authMiddleware.Parse(strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer "))
 	if err != nil {
-		log.Error(ctx, "createBundle: failed to parse auth token", err)
+		log.Error(ctx, "deleteBundle: failed to parse auth token", err)
 		code := models.CodeInternalServerError
 		e := &models.Error{
 			Code:        &code,

--- a/api/bundles.go
+++ b/api/bundles.go
@@ -60,8 +60,8 @@ func (api *BundleAPI) getBundles(w http.ResponseWriter, r *http.Request, limit, 
 
 func (api *BundleAPI) getBundle(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-
 	bundleID, logData := getBundleIDAndLogData(r)
+
 	bundle, err := api.stateMachineBundleAPI.GetBundle(ctx, bundleID)
 	if err != nil {
 		handleErr(ctx, w, r, err, logData, RouteNameGetBundle)
@@ -148,6 +148,17 @@ func getBundleIDAndLogData(r *http.Request) (string, log.Data) {
 	bundleID := vars[RouteVariableBundleID]
 	logData := log.Data{RouteVariableBundleID: bundleID}
 	return bundleID, logData
+}
+
+func getBundleIDAndContentIDAndLogData(r *http.Request) (bundleID, contentID string, logData log.Data) {
+	vars := mux.Vars(r)
+	bundleID = vars[RouteVariableBundleID]
+	contentID = vars[RouteVariableContentID]
+	logData = log.Data{
+		RouteVariableBundleID:  bundleID,
+		RouteVariableContentID: contentID,
+	}
+	return bundleID, contentID, logData
 }
 
 func setETagAndCacheControlHeaders(ctx context.Context, w http.ResponseWriter, r *http.Request, bundle *models.Bundle, logData log.Data) []byte {

--- a/api/bundles_test.go
+++ b/api/bundles_test.go
@@ -1794,7 +1794,7 @@ func TestDeleteBundle_Success(t *testing.T) {
 				}
 				return nil, errs.ErrBundleNotFound
 			},
-			ListBundleContentsWithoutLimitFunc: func(ctx context.Context, bundleID string) ([]*models.ContentItem, error) {
+			ListBundleContentIDsWithoutLimitFunc: func(ctx context.Context, bundleID string) ([]*models.ContentItem, error) {
 				return []*models.ContentItem{
 					{
 						ID: "content-1",

--- a/api/bundles_test.go
+++ b/api/bundles_test.go
@@ -1818,7 +1818,7 @@ func TestDeleteBundle_Success(t *testing.T) {
 			},
 		}
 
-		bundleAPI := GetBundleAPIWithMocks(store.Datastore{Backend: mockedDatastore})
+		bundleAPI := GetBundleAPIWithMocks(store.Datastore{Backend: mockedDatastore}, nil, false)
 		bundleAPI.Router.ServeHTTP(w, r)
 
 		Convey("Then the response should be 204 No Content", func() {
@@ -1835,7 +1835,7 @@ func TestDeleteBundle_Failure_UnableToParseToken(t *testing.T) {
 		w := httptest.NewRecorder()
 
 		mockedDatastore := &storetest.StorerMock{}
-		bundleAPI := GetBundleAPIWithMocks(store.Datastore{Backend: mockedDatastore})
+		bundleAPI := GetBundleAPIWithMocks(store.Datastore{Backend: mockedDatastore}, nil, false)
 
 		Convey("When the request is made", func() {
 			bundleAPI.Router.ServeHTTP(w, r)
@@ -1882,7 +1882,7 @@ func TestDeleteBundle_Failure_BundleNonExistent(t *testing.T) {
 			},
 		}
 
-		bundleAPI := GetBundleAPIWithMocks(store.Datastore{Backend: mockedDatastore})
+		bundleAPI := GetBundleAPIWithMocks(store.Datastore{Backend: mockedDatastore}, nil, false)
 		bundleAPI.Router.ServeHTTP(w, r)
 
 		Convey("Then the response should be 400 Not Found", func() {

--- a/api/bundles_test.go
+++ b/api/bundles_test.go
@@ -1252,3 +1252,133 @@ func TestCreateBundle_Failure_ScheduledAtIsInThePast(t *testing.T) {
 		})
 	})
 }
+
+func TestDeleteBundle_Success(t *testing.T) {
+	t.Parallel()
+
+	Convey("Given a DELETE /bundles/{bundle-id} request", t, func() {
+		r := httptest.NewRequest(http.MethodDelete, "/bundles/bundle-1", http.NoBody)
+		r.Header.Set("Authorization", "test-auth-token")
+		w := httptest.NewRecorder()
+
+		mockedDatastore := &storetest.StorerMock{
+			GetBundleFunc: func(ctx context.Context, id string) (*models.Bundle, error) {
+				if id == "bundle-1" {
+					return &models.Bundle{
+						ID:    "bundle-1",
+						State: models.BundleStateDraft,
+					}, nil
+				}
+				return nil, errs.ErrBundleNotFound
+			},
+			ListBundleContentsWithoutLimitFunc: func(ctx context.Context, bundleID string) ([]*models.ContentItem, int, error) {
+				return []*models.ContentItem{
+					{
+						ID: "content-1",
+					},
+					{
+						ID: "content-2",
+					},
+				}, 2, nil
+			},
+			DeleteContentItemFunc: func(ctx context.Context, contentItemID string) error {
+				if contentItemID == "content-1" || contentItemID == "content-2" {
+					return nil
+				}
+				return errors.New("failed to delete content item")
+			},
+			DeleteBundleFunc: func(ctx context.Context, id string) error {
+				return nil
+			},
+			CreateBundleEventFunc: func(ctx context.Context, event *models.Event) error {
+				return nil
+			},
+		}
+
+		bundleAPI := GetBundleAPIWithMocks(store.Datastore{Backend: mockedDatastore})
+		bundleAPI.Router.ServeHTTP(w, r)
+
+		Convey("Then the response should be 204 No Content", func() {
+			So(w.Code, ShouldEqual, http.StatusNoContent)
+		})
+	})
+}
+
+func TestDeleteBundle_Failure_UnableToParseToken(t *testing.T) {
+	t.Parallel()
+
+	Convey("Given a DELETE /bundles/{bundle-id} request with an invalid auth token", t, func() {
+		r := httptest.NewRequest(http.MethodDelete, "/bundles/bundle-1", http.NoBody)
+		w := httptest.NewRecorder()
+
+		mockedDatastore := &storetest.StorerMock{}
+		bundleAPI := GetBundleAPIWithMocks(store.Datastore{Backend: mockedDatastore})
+
+		Convey("When the request is made", func() {
+			bundleAPI.Router.ServeHTTP(w, r)
+
+			Convey("Then the response should be 500 Internal Server Error", func() {
+				So(w.Code, ShouldEqual, http.StatusInternalServerError)
+
+				var errResp models.ErrorList
+				err := json.NewDecoder(w.Body).Decode(&errResp)
+				So(err, ShouldBeNil)
+
+				code := models.CodeInternalServerError
+				expectedErrResp := models.ErrorList{
+					Errors: []*models.Error{
+						{
+							Code:        &code,
+							Description: errs.ErrorDescriptionInternalError,
+						},
+					},
+				}
+				So(errResp, ShouldResemble, expectedErrResp)
+			})
+		})
+	})
+}
+
+func TestDeleteBundle_Failure_BundleNonExistent(t *testing.T) {
+	t.Parallel()
+
+	Convey("Given a DELETE /bundles/{bundle-id} request", t, func() {
+		r := httptest.NewRequest(http.MethodDelete, "/bundles/bundle-2", http.NoBody)
+		r.Header.Set("Authorization", "test-auth-token")
+		w := httptest.NewRecorder()
+
+		mockedDatastore := &storetest.StorerMock{
+			GetBundleFunc: func(ctx context.Context, id string) (*models.Bundle, error) {
+				if id == "bundle-1" {
+					return &models.Bundle{
+						ID:    "bundle-1",
+						State: models.BundleStateDraft,
+					}, nil
+				}
+				return nil, errs.ErrBundleNotFound
+			},
+		}
+
+		bundleAPI := GetBundleAPIWithMocks(store.Datastore{Backend: mockedDatastore})
+		bundleAPI.Router.ServeHTTP(w, r)
+
+		Convey("Then the response should be 400 Not Found", func() {
+			So(w.Code, ShouldEqual, http.StatusNotFound)
+
+			var errResp models.ErrorList
+			err := json.NewDecoder(w.Body).Decode(&errResp)
+			So(err, ShouldBeNil)
+
+			code := models.CodeNotFound
+			expectedErrResp := models.ErrorList{
+				Errors: []*models.Error{
+					{
+						Code:        &code,
+						Description: errs.ErrorDescriptionNotFound,
+					},
+				},
+			}
+			So(errResp, ShouldResemble, expectedErrResp)
+		})
+	})
+}

--- a/api/bundles_test.go
+++ b/api/bundles_test.go
@@ -1271,7 +1271,7 @@ func TestDeleteBundle_Success(t *testing.T) {
 				}
 				return nil, errs.ErrBundleNotFound
 			},
-			ListBundleContentsWithoutLimitFunc: func(ctx context.Context, bundleID string) ([]*models.ContentItem, int, error) {
+			ListBundleContentsWithoutLimitFunc: func(ctx context.Context, bundleID string) ([]*models.ContentItem, error) {
 				return []*models.ContentItem{
 					{
 						ID: "content-1",
@@ -1279,7 +1279,7 @@ func TestDeleteBundle_Success(t *testing.T) {
 					{
 						ID: "content-2",
 					},
-				}, 2, nil
+				}, nil
 			},
 			DeleteContentItemFunc: func(ctx context.Context, contentItemID string) error {
 				if contentItemID == "content-1" || contentItemID == "content-2" {

--- a/api/contents.go
+++ b/api/contents.go
@@ -21,9 +21,9 @@ func (api *BundleAPI) postBundleContents(w http.ResponseWriter, r *http.Request)
 
 	ctx := r.Context()
 	vars := mux.Vars(r)
-	bundleID := vars["bundle-id"]
+	bundleID := vars[BundleIDPathParam]
 
-	logdata := log.Data{"bundle_id": bundleID}
+	logdata := log.Data{BundleIDPathParam: bundleID}
 
 	contentItem, err := models.CreateContentItem(r.Body)
 	if err != nil {
@@ -247,10 +247,10 @@ func (api *BundleAPI) postBundleContents(w http.ResponseWriter, r *http.Request)
 func (api *BundleAPI) deleteContentItem(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	vars := mux.Vars(r)
-	bundleID := vars["bundle-id"]
-	contentID := vars["content-id"]
+	bundleID := vars[BundleIDPathParam]
+	contentID := vars[ContentIDPathParam]
 
-	logdata := log.Data{"bundle_id": bundleID, "content_id": contentID}
+	logdata := log.Data{BundleIDPathParam: bundleID, ContentIDPathParam: contentID}
 
 	contentItem, err := api.stateMachineBundleAPI.Datastore.GetContentItemByBundleIDAndContentItemID(ctx, bundleID, contentID)
 	if err != nil {
@@ -360,8 +360,8 @@ func (api *BundleAPI) getBundleContents(w http.ResponseWriter, r *http.Request, 
 	// Fetch bundle ID
 	ctx := r.Context()
 	vars := mux.Vars(r)
-	bundleID := vars["bundle-id"]
-	logdata := log.Data{"bundle_id": bundleID}
+	bundleID := vars[BundleIDPathParam]
+	logdata := log.Data{BundleIDPathParam: bundleID}
 
 	// Check if the bundle exists
 	bundleExists, err := api.stateMachineBundleAPI.CheckBundleExists(ctx, bundleID)

--- a/api/contents.go
+++ b/api/contents.go
@@ -279,7 +279,7 @@ func (api *BundleAPI) deleteContentItem(w http.ResponseWriter, r *http.Request) 
 		code := models.CodeConflict
 		errInfo := &models.Error{
 			Code:        &code,
-			Description: apierrors.ErrorDescriptionContentItemAlreadyPublished,
+			Description: apierrors.ErrorDescriptionAlreadyPublished,
 		}
 		utils.HandleBundleAPIErr(w, r, http.StatusConflict, errInfo)
 		return

--- a/api/contents_test.go
+++ b/api/contents_test.go
@@ -1100,7 +1100,7 @@ func TestDeleteContentItem_ContentItemIsPublished_Failure(t *testing.T) {
 					Errors: []*models.Error{
 						{
 							Code:        &codeConflict,
-							Description: apierrors.ErrorDescriptionContentItemAlreadyPublished,
+							Description: apierrors.ErrorDescriptionAlreadyPublished,
 						},
 					},
 				}

--- a/apierrors/errors.go
+++ b/apierrors/errors.go
@@ -17,7 +17,7 @@ var (
 	ErrorDescriptionMissingParameters           = "Unable to process request due to missing required parameters in the request body or query parameters"
 	ErrorDescriptionNotFound                    = "The requested resource does not exist"
 	ErrorDescriptionInternalError               = "Failed to process the request due to an internal error"
-	ErrorDescriptionContentItemAlreadyPublished = "Change rejected due to a conflict with the current resource state. A common cause is attempting to change a bundle that is already locked pending publication or has already been published."
+	ErrorDescriptionAlreadyPublished            = "Change rejected due to a conflict with the current resource state. A common cause is attempting to change a bundle that is already locked pending publication or has already been published."
 	ErrorDescriptionInvalidTimeFormat           = "Invalid time format in request body"
 	ErrorDescriptionScheduledAtIsInPast         = "scheduled_at cannot be in the past"
 	ErrorDescriptionScheduledAtShouldNotBeSet   = "scheduled_at should not be set for manual bundles"

--- a/apierrors/errors.go
+++ b/apierrors/errors.go
@@ -15,11 +15,11 @@ func (e ErrInvalidPatch) Error() string {
 
 // Response error descriptions
 const (
-	ErrorDescriptionMalformedRequest            = "Unable to process request due to a malformed or invalid request body or query parameter"
-	ErrorDescriptionMissingParameters           = "Unable to process request due to missing required parameters in the request body or query parameters"
-	ErrorDescriptionNotFound                    = "The requested resource does not exist"
-	ErrorDescriptionInternalError               = "Failed to process the request due to an internal error"
-	ErrorDescriptionContentItemAlreadyPublished = "Change rejected due to a conflict with the current resource state. A common cause is attempting to change a bundle that is already locked pending publication or has already been published."
+	ErrorDescriptionMalformedRequest  = "Unable to process request due to a malformed or invalid request body or query parameter"
+	ErrorDescriptionMissingParameters = "Unable to process request due to missing required parameters in the request body or query parameters"
+	ErrorDescriptionNotFound          = "The requested resource does not exist"
+	ErrorDescriptionInternalError     = "Failed to process the request due to an internal error"
+	ErrorDescriptionAlreadyPublished  = "Change rejected due to a conflict with the current resource state. A common cause is attempting to change a bundle that is already locked pending publication or has already been published."
 
 	// Invalid etag
 	ErrorDescriptionMissingIfMatchHeader = "Unable to process request due to missing If-Match header"

--- a/application/application.go
+++ b/application/application.go
@@ -264,7 +264,7 @@ func (s *StateMachineBundleAPI) DeleteBundle(ctx context.Context, bundleID, emai
 		return http.StatusConflict, e, err
 	}
 
-	bundleContents, _, err := s.Datastore.ListBundleContentsWithoutLimit(ctx, bundleID)
+	bundleContents, err := s.Datastore.ListBundleContentsWithoutLimit(ctx, bundleID)
 
 	if err != nil {
 		log.Error(ctx, "failed to retrieve bundle contents", err, logData)

--- a/application/application.go
+++ b/application/application.go
@@ -341,7 +341,7 @@ func (s *StateMachineBundleAPI) DeleteBundle(ctx context.Context, bundleID, emai
 		return http.StatusConflict, e, err
 	}
 
-	bundleContents, err := s.Datastore.ListBundleContentsWithoutLimit(ctx, bundleID)
+	bundleContents, err := s.Datastore.ListBundleContentIDsWithoutLimit(ctx, bundleID)
 
 	if err != nil {
 		log.Error(ctx, "failed to retrieve bundle contents", err, logData)

--- a/application/application.go
+++ b/application/application.go
@@ -75,7 +75,7 @@ func (s *StateMachineBundleAPI) DeleteContentItem(ctx context.Context, contentIt
 	return s.Datastore.DeleteContentItem(ctx, contentItemID)
 }
 
-func (s *StateMachineBundleAPI) CreateEventFromBundle(ctx context.Context, bundle *models.Bundle, email string) (*models.Error, error) {
+func (s *StateMachineBundleAPI) CreateEventFromBundle(ctx context.Context, bundle *models.Bundle, email string, action models.Action) (*models.Error, error) {
 	bundleEvent, err := models.ConvertBundleToBundleEvent(bundle)
 	if err != nil {
 		log.Error(ctx, "failed to convert bundle to bundle event", err)
@@ -92,12 +92,48 @@ func (s *StateMachineBundleAPI) CreateEventFromBundle(ctx context.Context, bundl
 			ID:    email,
 			Email: email,
 		},
-		Action:   models.ActionCreate,
+		Action:   action,
 		Resource: "/bundles/" + bundle.ID,
 		Bundle:   bundleEvent,
 	}
 
 	err = models.ValidateEvent(event)
+	if err != nil {
+		log.Error(ctx, "failed to validate event", err)
+		code := models.CodeInternalServerError
+		e := &models.Error{
+			Code:        &code,
+			Description: errs.ErrorDescriptionInternalError,
+		}
+		return e, err
+	}
+
+	err = s.CreateBundleEvent(ctx, event)
+	if err != nil {
+		log.Error(ctx, "failed to create bundle event", err)
+		code := models.CodeInternalServerError
+		e := &models.Error{
+			Code:        &code,
+			Description: errs.ErrorDescriptionInternalError,
+		}
+		return e, err
+	}
+
+	return nil, nil
+}
+
+func (s *StateMachineBundleAPI) CreateEventFromContentItem(ctx context.Context, contentItem *models.ContentItem, email string, action models.Action) (*models.Error, error) {
+	event := &models.Event{
+		RequestedBy: &models.RequestedBy{
+			ID:    email,
+			Email: email,
+		},
+		Action:      action,
+		Resource:    "/bundles/" + contentItem.BundleID + "/contents/" + contentItem.ID,
+		ContentItem: contentItem,
+	}
+
+	err := models.ValidateEvent(event)
 	if err != nil {
 		log.Error(ctx, "failed to validate event", err)
 		code := models.CodeInternalServerError
@@ -184,13 +220,101 @@ func (s *StateMachineBundleAPI) CreateBundle(ctx context.Context, bundle *models
 		return http.StatusInternalServerError, nil, e, err
 	}
 
-	errObject, err := s.CreateEventFromBundle(ctx, bundle, createdBundle.CreatedBy.Email)
+	errObject, err := s.CreateEventFromBundle(ctx, bundle, createdBundle.CreatedBy.Email, models.ActionCreate)
 	if err != nil {
 		log.Error(ctx, "failed to create event from bundle", err)
 		return http.StatusInternalServerError, nil, errObject, err
 	}
 
 	return http.StatusCreated, createdBundle, nil, nil
+}
+
+func (s *StateMachineBundleAPI) DeleteBundle(ctx context.Context, bundleID, email string) (int, *models.Error, error) {
+	logData := log.Data{"bundle_id": bundleID}
+
+	bundle, err := s.GetBundle(ctx, bundleID)
+	if err != nil {
+		if err == errs.ErrBundleNotFound {
+			log.Error(ctx, "bundle not found", err, logData)
+			code := models.CodeNotFound
+			e := &models.Error{
+				Code:        &code,
+				Description: errs.ErrorDescriptionNotFound,
+			}
+			return http.StatusNotFound, e, err
+		} else {
+			log.Error(ctx, "failed to get bundle", err, logData)
+			code := models.CodeInternalServerError
+			e := &models.Error{
+				Code:        &code,
+				Description: errs.ErrorDescriptionInternalError,
+			}
+			return http.StatusInternalServerError, e, err
+		}
+	}
+
+	err = s.StateMachine.Transition(ctx, s, bundle, nil)
+	if err != nil {
+		log.Error(ctx, "failed to transition bundle state", err, logData)
+		code := models.CodeConflict
+		e := &models.Error{
+			Code:        &code,
+			Description: errs.ErrorDescriptionAlreadyPublished,
+		}
+		return http.StatusConflict, e, err
+	}
+
+	bundleContents, _, err := s.Datastore.ListBundleContentsWithoutLimit(ctx, bundleID)
+
+	if err != nil {
+		log.Error(ctx, "failed to retrieve bundle contents", err, logData)
+		code := models.CodeInternalServerError
+		e := &models.Error{
+			Code:        &code,
+			Description: errs.ErrorDescriptionInternalError,
+		}
+		return http.StatusInternalServerError, e, err
+	}
+
+	if len(bundleContents) > 0 {
+		for _, contentItem := range bundleContents {
+			err = s.DeleteContentItem(ctx, contentItem.ID)
+			if err != nil {
+				log.Error(ctx, "failed to delete content item", err, log.Data{"bundle_id": bundleID, "content_item_id": contentItem.ID})
+				code := models.CodeInternalServerError
+				e := &models.Error{
+					Code:        &code,
+					Description: errs.ErrorDescriptionInternalError,
+				}
+				return http.StatusInternalServerError, e, err
+			}
+
+			errObject, err := s.CreateEventFromContentItem(ctx, contentItem, email, models.ActionDelete)
+			if err != nil {
+				log.Error(ctx, "failed to create event from content item", err, log.Data{"bundle_id": bundleID, "content_item_id": contentItem.ID})
+				return http.StatusInternalServerError, errObject, err
+			}
+		}
+	}
+
+	err = s.Datastore.DeleteBundle(ctx, bundleID)
+	if err != nil {
+		log.Error(ctx, "failed to delete bundle", err, logData)
+		code := models.CodeInternalServerError
+		e := &models.Error{
+			Code:        &code,
+			Description: errs.ErrorDescriptionInternalError,
+		}
+		return http.StatusInternalServerError, e, err
+	}
+
+	errObject, err := s.CreateEventFromBundle(ctx, bundle, email, models.ActionDelete)
+	if err != nil {
+		log.Error(ctx, "failed to create event from bundle", err, logData)
+		return http.StatusInternalServerError, errObject, err
+	}
+
+	return http.StatusNoContent, nil, nil
 }
 
 func (s *StateMachineBundleAPI) CheckBundleExistsByTitle(ctx context.Context, title string) (bool, error) {

--- a/application/application.go
+++ b/application/application.go
@@ -81,7 +81,6 @@ func (s *StateMachineBundleAPI) DeleteContentItem(ctx context.Context, contentIt
 func (s *StateMachineBundleAPI) CreateEventFromBundle(ctx context.Context, bundle *models.Bundle, email string, action models.Action) (*models.Error, error) {
 	bundleEvent, err := models.ConvertBundleToBundleEvent(bundle)
 	if err != nil {
-		log.Error(ctx, "failed to convert bundle to bundle event", err)
 		code := models.CodeInternalServerError
 		e := &models.Error{
 			Code:        &code,
@@ -102,7 +101,6 @@ func (s *StateMachineBundleAPI) CreateEventFromBundle(ctx context.Context, bundl
 
 	err = models.ValidateEvent(event)
 	if err != nil {
-		log.Error(ctx, "failed to validate event", err)
 		code := models.CodeInternalServerError
 		e := &models.Error{
 			Code:        &code,
@@ -113,7 +111,6 @@ func (s *StateMachineBundleAPI) CreateEventFromBundle(ctx context.Context, bundl
 
 	err = s.CreateBundleEvent(ctx, event)
 	if err != nil {
-		log.Error(ctx, "failed to create bundle event", err)
 		code := models.CodeInternalServerError
 		e := &models.Error{
 			Code:        &code,
@@ -138,7 +135,6 @@ func (s *StateMachineBundleAPI) CreateEventFromContentItem(ctx context.Context, 
 
 	err := models.ValidateEvent(event)
 	if err != nil {
-		log.Error(ctx, "failed to validate event", err)
 		code := models.CodeInternalServerError
 		e := &models.Error{
 			Code:        &code,
@@ -149,7 +145,6 @@ func (s *StateMachineBundleAPI) CreateEventFromContentItem(ctx context.Context, 
 
 	err = s.CreateBundleEvent(ctx, event)
 	if err != nil {
-		log.Error(ctx, "failed to create bundle event", err)
 		code := models.CodeInternalServerError
 		e := &models.Error{
 			Code:        &code,
@@ -307,12 +302,9 @@ func (s *StateMachineBundleAPI) CreateBundle(ctx context.Context, bundle *models
 }
 
 func (s *StateMachineBundleAPI) DeleteBundle(ctx context.Context, bundleID, email string) (int, *models.Error, error) {
-	logData := log.Data{"bundle_id": bundleID}
-
 	bundle, err := s.GetBundle(ctx, bundleID)
 	if err != nil {
 		if err == errs.ErrBundleNotFound {
-			log.Error(ctx, "bundle not found", err, logData)
 			code := models.CodeNotFound
 			e := &models.Error{
 				Code:        &code,
@@ -320,7 +312,6 @@ func (s *StateMachineBundleAPI) DeleteBundle(ctx context.Context, bundleID, emai
 			}
 			return http.StatusNotFound, e, err
 		} else {
-			log.Error(ctx, "failed to get bundle", err, logData)
 			code := models.CodeInternalServerError
 			e := &models.Error{
 				Code:        &code,
@@ -332,7 +323,6 @@ func (s *StateMachineBundleAPI) DeleteBundle(ctx context.Context, bundleID, emai
 
 	err = s.StateMachine.Transition(ctx, s, bundle, nil)
 	if err != nil {
-		log.Error(ctx, "failed to transition bundle state", err, logData)
 		code := models.CodeConflict
 		e := &models.Error{
 			Code:        &code,
@@ -344,7 +334,6 @@ func (s *StateMachineBundleAPI) DeleteBundle(ctx context.Context, bundleID, emai
 	bundleContents, err := s.Datastore.ListBundleContentIDsWithoutLimit(ctx, bundleID)
 
 	if err != nil {
-		log.Error(ctx, "failed to retrieve bundle contents", err, logData)
 		code := models.CodeInternalServerError
 		e := &models.Error{
 			Code:        &code,
@@ -368,7 +357,6 @@ func (s *StateMachineBundleAPI) DeleteBundle(ctx context.Context, bundleID, emai
 
 			errObject, err := s.CreateEventFromContentItem(ctx, contentItem, email, models.ActionDelete)
 			if err != nil {
-				log.Error(ctx, "failed to create event from content item", err, log.Data{"bundle_id": bundleID, "content_item_id": contentItem.ID})
 				return http.StatusInternalServerError, errObject, err
 			}
 		}
@@ -376,7 +364,6 @@ func (s *StateMachineBundleAPI) DeleteBundle(ctx context.Context, bundleID, emai
 
 	err = s.Datastore.DeleteBundle(ctx, bundleID)
 	if err != nil {
-		log.Error(ctx, "failed to delete bundle", err, logData)
 		code := models.CodeInternalServerError
 		e := &models.Error{
 			Code:        &code,
@@ -387,7 +374,6 @@ func (s *StateMachineBundleAPI) DeleteBundle(ctx context.Context, bundleID, emai
 
 	errObject, err := s.CreateEventFromBundle(ctx, bundle, email, models.ActionDelete)
 	if err != nil {
-		log.Error(ctx, "failed to create event from bundle", err, logData)
 		return http.StatusInternalServerError, errObject, err
 	}
 

--- a/application/application_test.go
+++ b/application/application_test.go
@@ -1129,7 +1129,7 @@ func TestDeleteBundle_Success(t *testing.T) {
 				}
 				return nil, apierrors.ErrBundleNotFound
 			},
-			ListBundleContentsWithoutLimitFunc: func(ctx context.Context, bundleID string) ([]*models.ContentItem, int, error) {
+			ListBundleContentsWithoutLimitFunc: func(ctx context.Context, bundleID string) ([]*models.ContentItem, error) {
 				return []*models.ContentItem{
 					{
 						ID: "content-1",
@@ -1137,7 +1137,7 @@ func TestDeleteBundle_Success(t *testing.T) {
 					{
 						ID: "content-2",
 					},
-				}, 2, nil
+				}, nil
 			},
 			DeleteContentItemFunc: func(ctx context.Context, contentItemID string) error {
 				if contentItemID == "content-1" || contentItemID == "content-2" {
@@ -1278,8 +1278,8 @@ func TestDeleteBundle_Failure_ListBundleContents(t *testing.T) {
 					State: models.BundleStateDraft,
 				}, nil
 			},
-			ListBundleContentsWithoutLimitFunc: func(ctx context.Context, bundleID string) ([]*models.ContentItem, int, error) {
-				return nil, 0, errors.New("failed to list bundle contents")
+			ListBundleContentsWithoutLimitFunc: func(ctx context.Context, bundleID string) ([]*models.ContentItem, error) {
+				return nil, errors.New("failed to list bundle contents")
 			},
 		}
 
@@ -1320,11 +1320,11 @@ func TestDeleteBundle_Failure_DeleteContentItem(t *testing.T) {
 					State: models.BundleStateDraft,
 				}, nil
 			},
-			ListBundleContentsWithoutLimitFunc: func(ctx context.Context, bundleID string) ([]*models.ContentItem, int, error) {
+			ListBundleContentsWithoutLimitFunc: func(ctx context.Context, bundleID string) ([]*models.ContentItem, error) {
 				return []*models.ContentItem{
 					{ID: "content-1"},
 					{ID: "content-2"},
-				}, 2, nil
+				}, nil
 			},
 			DeleteContentItemFunc: func(ctx context.Context, contentItemID string) error {
 				return errors.New("failed to delete content item")
@@ -1368,10 +1368,10 @@ func TestDeleteBundle_Failure_CreateEventFromContentItem(t *testing.T) {
 					State: models.BundleStateDraft,
 				}, nil
 			},
-			ListBundleContentsWithoutLimitFunc: func(ctx context.Context, bundleID string) ([]*models.ContentItem, int, error) {
+			ListBundleContentsWithoutLimitFunc: func(ctx context.Context, bundleID string) ([]*models.ContentItem, error) {
 				return []*models.ContentItem{
 					{ID: "content-1"},
-				}, 1, nil
+				}, nil
 			},
 			DeleteContentItemFunc: func(ctx context.Context, contentItemID string) error {
 				return nil
@@ -1418,8 +1418,8 @@ func TestDeleteBundle_Failure_DeleteBundle(t *testing.T) {
 					State: models.BundleStateDraft,
 				}, nil
 			},
-			ListBundleContentsWithoutLimitFunc: func(ctx context.Context, bundleID string) ([]*models.ContentItem, int, error) {
-				return []*models.ContentItem{}, 0, nil
+			ListBundleContentsWithoutLimitFunc: func(ctx context.Context, bundleID string) ([]*models.ContentItem, error) {
+				return []*models.ContentItem{}, nil
 			},
 			DeleteContentItemFunc: func(ctx context.Context, contentItemID string) error {
 				return nil
@@ -1466,8 +1466,8 @@ func TestDeleteBundle_Failure_CreateEventFromBundle(t *testing.T) {
 					State: models.BundleStateDraft,
 				}, nil
 			},
-			ListBundleContentsWithoutLimitFunc: func(ctx context.Context, bundleID string) ([]*models.ContentItem, int, error) {
-				return []*models.ContentItem{}, 0, nil
+			ListBundleContentsWithoutLimitFunc: func(ctx context.Context, bundleID string) ([]*models.ContentItem, error) {
+				return []*models.ContentItem{}, nil
 			},
 			DeleteContentItemFunc: func(ctx context.Context, contentItemID string) error {
 				return nil

--- a/application/application_test.go
+++ b/application/application_test.go
@@ -1129,7 +1129,7 @@ func TestDeleteBundle_Success(t *testing.T) {
 				}
 				return nil, apierrors.ErrBundleNotFound
 			},
-			ListBundleContentsWithoutLimitFunc: func(ctx context.Context, bundleID string) ([]*models.ContentItem, error) {
+			ListBundleContentIDsWithoutLimitFunc: func(ctx context.Context, bundleID string) ([]*models.ContentItem, error) {
 				return []*models.ContentItem{
 					{
 						ID: "content-1",
@@ -1267,7 +1267,7 @@ func TestDeleteBundle_Failure_Transition(t *testing.T) {
 	})
 }
 
-func TestDeleteBundle_Failure_ListBundleContents(t *testing.T) {
+func TestDeleteBundle_Failure_ListBundleContentIDsWithoutLimit(t *testing.T) {
 	Convey("Given a StateMachineBundleAPI with a mocked datastore", t, func() {
 		ctx := context.Background()
 
@@ -1278,7 +1278,7 @@ func TestDeleteBundle_Failure_ListBundleContents(t *testing.T) {
 					State: models.BundleStateDraft,
 				}, nil
 			},
-			ListBundleContentsWithoutLimitFunc: func(ctx context.Context, bundleID string) ([]*models.ContentItem, error) {
+			ListBundleContentIDsWithoutLimitFunc: func(ctx context.Context, bundleID string) ([]*models.ContentItem, error) {
 				return nil, errors.New("failed to list bundle contents")
 			},
 		}
@@ -1320,7 +1320,7 @@ func TestDeleteBundle_Failure_DeleteContentItem(t *testing.T) {
 					State: models.BundleStateDraft,
 				}, nil
 			},
-			ListBundleContentsWithoutLimitFunc: func(ctx context.Context, bundleID string) ([]*models.ContentItem, error) {
+			ListBundleContentIDsWithoutLimitFunc: func(ctx context.Context, bundleID string) ([]*models.ContentItem, error) {
 				return []*models.ContentItem{
 					{ID: "content-1"},
 					{ID: "content-2"},
@@ -1368,7 +1368,7 @@ func TestDeleteBundle_Failure_CreateEventFromContentItem(t *testing.T) {
 					State: models.BundleStateDraft,
 				}, nil
 			},
-			ListBundleContentsWithoutLimitFunc: func(ctx context.Context, bundleID string) ([]*models.ContentItem, error) {
+			ListBundleContentIDsWithoutLimitFunc: func(ctx context.Context, bundleID string) ([]*models.ContentItem, error) {
 				return []*models.ContentItem{
 					{ID: "content-1"},
 				}, nil
@@ -1418,7 +1418,7 @@ func TestDeleteBundle_Failure_DeleteBundle(t *testing.T) {
 					State: models.BundleStateDraft,
 				}, nil
 			},
-			ListBundleContentsWithoutLimitFunc: func(ctx context.Context, bundleID string) ([]*models.ContentItem, error) {
+			ListBundleContentIDsWithoutLimitFunc: func(ctx context.Context, bundleID string) ([]*models.ContentItem, error) {
 				return []*models.ContentItem{}, nil
 			},
 			DeleteContentItemFunc: func(ctx context.Context, contentItemID string) error {
@@ -1466,7 +1466,7 @@ func TestDeleteBundle_Failure_CreateEventFromBundle(t *testing.T) {
 					State: models.BundleStateDraft,
 				}, nil
 			},
-			ListBundleContentsWithoutLimitFunc: func(ctx context.Context, bundleID string) ([]*models.ContentItem, error) {
+			ListBundleContentIDsWithoutLimitFunc: func(ctx context.Context, bundleID string) ([]*models.ContentItem, error) {
 				return []*models.ContentItem{}, nil
 			},
 			DeleteContentItemFunc: func(ctx context.Context, contentItemID string) error {

--- a/application/application_test.go
+++ b/application/application_test.go
@@ -362,7 +362,7 @@ func TestCreateEventFromBundle_Success(t *testing.T) {
 		}
 
 		Convey("When CreateEventFromBundle is called with a valid bundle", func() {
-			errorObject, err := stateMachine.CreateEventFromBundle(ctx, &fullyPopulatedBundle, "test@email.com")
+			errorObject, err := stateMachine.CreateEventFromBundle(ctx, &fullyPopulatedBundle, "test@email.com", models.ActionCreate)
 
 			Convey("Then it should return no error", func() {
 				So(errorObject, ShouldBeNil)
@@ -387,7 +387,7 @@ func TestCreateEventFromBundle_ConvertBundleToBundleEvent_Failure(t *testing.T) 
 		}
 
 		Convey("When CreateEventFromBundle is called with a nil bundle", func() {
-			errorObject, err := stateMachine.CreateEventFromBundle(ctx, nil, "test@email.com")
+			errorObject, err := stateMachine.CreateEventFromBundle(ctx, nil, "test@email.com", models.ActionCreate)
 
 			Convey("Then it should return an input bundle cannot be nil error", func() {
 				So(err, ShouldNotBeNil)
@@ -421,7 +421,7 @@ func TestCreateEventFromBundle_CreateBundleEvent_Failure(t *testing.T) {
 		}
 
 		Convey("When CreateEventFromBundle is called with a valid bundle", func() {
-			errorObject, err := stateMachine.CreateEventFromBundle(ctx, &fullyPopulatedBundle, "test@email.com")
+			errorObject, err := stateMachine.CreateEventFromBundle(ctx, &fullyPopulatedBundle, "test@email.com", models.ActionCreate)
 
 			Convey("Then it should return an error", func() {
 				So(err, ShouldNotBeNil)
@@ -1111,6 +1111,397 @@ func TestGetBundleContents(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(items, ShouldBeEmpty)
 			So(total, ShouldEqual, 0)
+		})
+	})
+}
+
+func TestDeleteBundle_Success(t *testing.T) {
+	Convey("Given a StateMachineBundleAPI with a mocked datastore", t, func() {
+		ctx := context.Background()
+
+		mockedDatastore := &storetest.StorerMock{
+			GetBundleFunc: func(ctx context.Context, id string) (*models.Bundle, error) {
+				if id == "bundle-1" {
+					return &models.Bundle{
+						ID:    "bundle-1",
+						State: models.BundleStateDraft,
+					}, nil
+				}
+				return nil, apierrors.ErrBundleNotFound
+			},
+			ListBundleContentsWithoutLimitFunc: func(ctx context.Context, bundleID string) ([]*models.ContentItem, int, error) {
+				return []*models.ContentItem{
+					{
+						ID: "content-1",
+					},
+					{
+						ID: "content-2",
+					},
+				}, 2, nil
+			},
+			DeleteContentItemFunc: func(ctx context.Context, contentItemID string) error {
+				if contentItemID == "content-1" || contentItemID == "content-2" {
+					return nil
+				}
+				return errors.New("failed to delete content item")
+			},
+			DeleteBundleFunc: func(ctx context.Context, id string) error {
+				return nil
+			},
+			CreateBundleEventFunc: func(ctx context.Context, event *models.Event) error {
+				return nil
+			},
+		}
+
+		stateMachine := &application.StateMachineBundleAPI{
+			Datastore: store.Datastore{Backend: mockedDatastore},
+		}
+
+		Convey("When DeleteBundle is called with an existing bundle ID", func() {
+			statusCode, errObject, err := stateMachine.DeleteBundle(ctx, "bundle-1", "example@email.com")
+
+			Convey("Then it should return a status code of 204 and no error", func() {
+				So(err, ShouldBeNil)
+				So(errObject, ShouldBeNil)
+				So(statusCode, ShouldEqual, 204)
+			})
+		})
+	})
+}
+
+func TestDeleteBundle_Failure_GetBundle(t *testing.T) {
+	Convey("Given a StateMachineBundleAPI with a mocked datastore", t, func() {
+		ctx := context.Background()
+
+		mockedDatastore := &storetest.StorerMock{
+			GetBundleFunc: func(ctx context.Context, id string) (*models.Bundle, error) {
+				if id == "bundle-1" {
+					return nil, apierrors.ErrBundleNotFound
+				}
+				return nil, errors.New("unexpected error")
+			},
+		}
+
+		stateMachine := &application.StateMachineBundleAPI{
+			Datastore: store.Datastore{Backend: mockedDatastore},
+		}
+
+		Convey("When DeleteBundle is called with a non-existing bundle ID", func() {
+			statusCode, errObject, err := stateMachine.DeleteBundle(ctx, "bundle-1", "email@example.com")
+
+			Convey("Then it should return a 404 Not Found error", func() {
+				So(statusCode, ShouldEqual, 404)
+			})
+
+			Convey("And the errorObject/error should indicate the bundle was not found", func() {
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldEqual, apierrors.ErrBundleNotFound.Error())
+
+				code := models.CodeNotFound
+				expectedErr := &models.Error{
+					Code:        &code,
+					Description: apierrors.ErrorDescriptionNotFound,
+				}
+				So(errObject, ShouldResemble, expectedErr)
+			})
+		})
+
+		Convey("When DeleteBundle is called and the datastore returns an unexpected error", func() {
+			statusCode, errObject, err := stateMachine.DeleteBundle(ctx, "unexpected-error", "email@example.com")
+
+			Convey("Then it should return a 500 Internal Server Error", func() {
+				So(statusCode, ShouldEqual, 500)
+			})
+
+			Convey("And the errorObject/error should indicate an internal server error", func() {
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldEqual, "unexpected error")
+
+				code := models.CodeInternalServerError
+				expectedErr := &models.Error{
+					Code:        &code,
+					Description: apierrors.ErrorDescriptionInternalError,
+				}
+				So(errObject, ShouldResemble, expectedErr)
+			})
+		})
+	})
+}
+
+func TestDeleteBundle_Failure_Transition(t *testing.T) {
+	Convey("Given a StateMachineBundleAPI with a mocked datastore", t, func() {
+		ctx := context.Background()
+
+		mockedDatastore := &storetest.StorerMock{
+			GetBundleFunc: func(ctx context.Context, id string) (*models.Bundle, error) {
+				return &models.Bundle{
+					ID:    "bundle-1",
+					State: models.BundleStatePublished,
+				}, nil
+			},
+		}
+
+		stateMachine := &application.StateMachineBundleAPI{
+			Datastore: store.Datastore{Backend: mockedDatastore},
+		}
+
+		Convey("When DeleteBundle is called with a bundle that is already published", func() {
+			statusCode, errObject, err := stateMachine.DeleteBundle(ctx, "bundle-1", "email@example.com")
+
+			Convey("Then it should return a 409 Conflict error", func() {
+				So(statusCode, ShouldEqual, 409)
+			})
+
+			Convey("And the errorObject/error should indicate the bundle cannot be deleted", func() {
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldEqual, "cannot update a published bundle")
+
+				code := models.CodeConflict
+				expectedErr := &models.Error{
+					Code:        &code,
+					Description: apierrors.ErrorDescriptionAlreadyPublished,
+				}
+				So(errObject, ShouldResemble, expectedErr)
+			})
+		})
+	})
+}
+
+func TestDeleteBundle_Failure_ListBundleContents(t *testing.T) {
+	Convey("Given a StateMachineBundleAPI with a mocked datastore", t, func() {
+		ctx := context.Background()
+
+		mockedDatastore := &storetest.StorerMock{
+			GetBundleFunc: func(ctx context.Context, id string) (*models.Bundle, error) {
+				return &models.Bundle{
+					ID:    "bundle-1",
+					State: models.BundleStateDraft,
+				}, nil
+			},
+			ListBundleContentsWithoutLimitFunc: func(ctx context.Context, bundleID string) ([]*models.ContentItem, int, error) {
+				return nil, 0, errors.New("failed to list bundle contents")
+			},
+		}
+
+		stateMachine := &application.StateMachineBundleAPI{
+			Datastore: store.Datastore{Backend: mockedDatastore},
+		}
+
+		Convey("When DeleteBundle is called and listing bundle contents fails", func() {
+			statusCode, errObject, err := stateMachine.DeleteBundle(ctx, "bundle-1", "email@example.com")
+
+			Convey("Then it should return a 500 Internal Server Error", func() {
+				So(statusCode, ShouldEqual, 500)
+			})
+
+			Convey("And the errorObject/error should indicate an internal server error", func() {
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldEqual, "failed to list bundle contents")
+
+				code := models.CodeInternalServerError
+				expectedErr := &models.Error{
+					Code:        &code,
+					Description: apierrors.ErrorDescriptionInternalError,
+				}
+				So(errObject, ShouldResemble, expectedErr)
+			})
+		})
+	})
+}
+
+func TestDeleteBundle_Failure_DeleteContentItem(t *testing.T) {
+	Convey("Given a StateMachineBundleAPI with a mocked datastore", t, func() {
+		ctx := context.Background()
+
+		mockedDatastore := &storetest.StorerMock{
+			GetBundleFunc: func(ctx context.Context, id string) (*models.Bundle, error) {
+				return &models.Bundle{
+					ID:    "bundle-1",
+					State: models.BundleStateDraft,
+				}, nil
+			},
+			ListBundleContentsWithoutLimitFunc: func(ctx context.Context, bundleID string) ([]*models.ContentItem, int, error) {
+				return []*models.ContentItem{
+					{ID: "content-1"},
+					{ID: "content-2"},
+				}, 2, nil
+			},
+			DeleteContentItemFunc: func(ctx context.Context, contentItemID string) error {
+				return errors.New("failed to delete content item")
+			},
+		}
+
+		stateMachine := &application.StateMachineBundleAPI{
+			Datastore: store.Datastore{Backend: mockedDatastore},
+		}
+
+		Convey("When DeleteBundle is called and deleting a content item fails", func() {
+			statusCode, errObject, err := stateMachine.DeleteBundle(ctx, "bundle-1", "email@example.com")
+
+			Convey("Then it should return a 500 Internal Server Error", func() {
+				So(statusCode, ShouldEqual, 500)
+			})
+
+			Convey("And the errorObject/error should indicate an internal server error", func() {
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldEqual, "failed to delete content item")
+
+				code := models.CodeInternalServerError
+				expectedErr := &models.Error{
+					Code:        &code,
+					Description: apierrors.ErrorDescriptionInternalError,
+				}
+				So(errObject, ShouldResemble, expectedErr)
+			})
+		})
+	})
+}
+
+func TestDeleteBundle_Failure_CreateEventFromContentItem(t *testing.T) {
+	Convey("Given a StateMachineBundleAPI with a mocked datastore", t, func() {
+		ctx := context.Background()
+
+		mockedDatastore := &storetest.StorerMock{
+			GetBundleFunc: func(ctx context.Context, id string) (*models.Bundle, error) {
+				return &models.Bundle{
+					ID:    "bundle-1",
+					State: models.BundleStateDraft,
+				}, nil
+			},
+			ListBundleContentsWithoutLimitFunc: func(ctx context.Context, bundleID string) ([]*models.ContentItem, int, error) {
+				return []*models.ContentItem{
+					{ID: "content-1"},
+				}, 1, nil
+			},
+			DeleteContentItemFunc: func(ctx context.Context, contentItemID string) error {
+				return nil
+			},
+			CreateBundleEventFunc: func(ctx context.Context, event *models.Event) error {
+				return errors.New("failed to create event from content item")
+			},
+		}
+
+		stateMachine := &application.StateMachineBundleAPI{
+			Datastore: store.Datastore{Backend: mockedDatastore},
+		}
+
+		Convey("When DeleteBundle is called and creating an event from content item fails", func() {
+			statusCode, errObject, err := stateMachine.DeleteBundle(ctx, "bundle-1", "email@example.com")
+
+			Convey("Then it should return a 500 Internal Server Error", func() {
+				So(statusCode, ShouldEqual, 500)
+			})
+
+			Convey("And the errorObject/error should indicate an internal server error", func() {
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldEqual, "failed to create event from content item")
+
+				code := models.CodeInternalServerError
+				expectedErr := &models.Error{
+					Code:        &code,
+					Description: apierrors.ErrorDescriptionInternalError,
+				}
+				So(errObject, ShouldResemble, expectedErr)
+			})
+		})
+	})
+}
+
+func TestDeleteBundle_Failure_DeleteBundle(t *testing.T) {
+	Convey("Given a StateMachineBundleAPI with a mocked datastore", t, func() {
+		ctx := context.Background()
+
+		mockedDatastore := &storetest.StorerMock{
+			GetBundleFunc: func(ctx context.Context, id string) (*models.Bundle, error) {
+				return &models.Bundle{
+					ID:    "bundle-1",
+					State: models.BundleStateDraft,
+				}, nil
+			},
+			ListBundleContentsWithoutLimitFunc: func(ctx context.Context, bundleID string) ([]*models.ContentItem, int, error) {
+				return []*models.ContentItem{}, 0, nil
+			},
+			DeleteContentItemFunc: func(ctx context.Context, contentItemID string) error {
+				return nil
+			},
+			DeleteBundleFunc: func(ctx context.Context, id string) error {
+				return errors.New("failed to delete bundle")
+			},
+		}
+
+		stateMachine := &application.StateMachineBundleAPI{
+			Datastore: store.Datastore{Backend: mockedDatastore},
+		}
+
+		Convey("When DeleteBundle is called and deleting the bundle fails", func() {
+			statusCode, errObject, err := stateMachine.DeleteBundle(ctx, "bundle-1", "email@example.com")
+
+			Convey("Then it should return a 500 Internal Server Error", func() {
+				So(statusCode, ShouldEqual, 500)
+			})
+
+			Convey("And the errorObject/error should indicate an internal server error", func() {
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldEqual, "failed to delete bundle")
+
+				code := models.CodeInternalServerError
+				expectedErr := &models.Error{
+					Code:        &code,
+					Description: apierrors.ErrorDescriptionInternalError,
+				}
+				So(errObject, ShouldResemble, expectedErr)
+			})
+		})
+	})
+}
+
+func TestDeleteBundle_Failure_CreateEventFromBundle(t *testing.T) {
+	Convey("Given a StateMachineBundleAPI with a mocked datastore", t, func() {
+		ctx := context.Background()
+
+		mockedDatastore := &storetest.StorerMock{
+			GetBundleFunc: func(ctx context.Context, id string) (*models.Bundle, error) {
+				return &models.Bundle{
+					ID:    "bundle-1",
+					State: models.BundleStateDraft,
+				}, nil
+			},
+			ListBundleContentsWithoutLimitFunc: func(ctx context.Context, bundleID string) ([]*models.ContentItem, int, error) {
+				return []*models.ContentItem{}, 0, nil
+			},
+			DeleteContentItemFunc: func(ctx context.Context, contentItemID string) error {
+				return nil
+			},
+			DeleteBundleFunc: func(ctx context.Context, id string) error {
+				return nil
+			},
+			CreateBundleEventFunc: func(ctx context.Context, event *models.Event) error {
+				return errors.New("failed to create event from bundle")
+			},
+		}
+
+		stateMachine := &application.StateMachineBundleAPI{
+			Datastore: store.Datastore{Backend: mockedDatastore},
+		}
+
+		Convey("When DeleteBundle is called and creating an event from the bundle fails", func() {
+			statusCode, errObject, err := stateMachine.DeleteBundle(ctx, "bundle-1", "email@example.com")
+
+			Convey("Then it should return a 500 Internal Server Error", func() {
+				So(statusCode, ShouldEqual, 500)
+			})
+
+			Convey("And the errorObject/error should indicate an internal server error", func() {
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldEqual, "failed to create event from bundle")
+
+				code := models.CodeInternalServerError
+				expectedErr := &models.Error{
+					Code:        &code,
+					Description: apierrors.ErrorDescriptionInternalError,
+				}
+				So(errObject, ShouldResemble, expectedErr)
+			})
 		})
 	})
 }

--- a/application/state_machine.go
+++ b/application/state_machine.go
@@ -79,6 +79,13 @@ func (sm *StateMachine) Transition(ctx context.Context, stateMachineBundleAPI *S
 		}
 	}
 
+	if bundleUpdate == nil {
+		if currentBundle.State.String() == models.BundleStatePublished.String() {
+			return errors.New("cannot update a published bundle")
+		}
+		return nil
+	}
+
 	for state, transitions := range sm.transitions {
 		if state == bundleUpdate.State.String() {
 			for i := range transitions {

--- a/application/state_machine_test.go
+++ b/application/state_machine_test.go
@@ -13,10 +13,11 @@ import (
 )
 
 var (
-	currentBundleWithStateDraft    = &models.Bundle{State: models.BundleStateDraft}
-	currentBundleWithStateInReview = &models.Bundle{State: models.BundleStateInReview}
-	currentBundleWithStateApproved = &models.Bundle{State: models.BundleStateApproved}
-	currentBundleWithStateUnknown  = &models.Bundle{State: models.BundleState("UNKNOWN")}
+	currentBundleWithStateDraft     = &models.Bundle{State: models.BundleStateDraft}
+	currentBundleWithStateInReview  = &models.Bundle{State: models.BundleStateInReview}
+	currentBundleWithStateApproved  = &models.Bundle{State: models.BundleStateApproved}
+	currentBundleWithStatePublished = &models.Bundle{State: models.BundleStatePublished}
+	currentBundleWithStateUnknown   = &models.Bundle{State: models.BundleState("UNKNOWN")}
 
 	bundleUpdateWithStateDraft     = &models.Bundle{State: models.BundleStateDraft}
 	bundleUpdateWithStateInReview  = &models.Bundle{State: models.BundleStateInReview}
@@ -186,6 +187,14 @@ func TestTransition_success(t *testing.T) {
 			So(err, ShouldBeNil)
 		})
 	})
+
+	Convey("When transitioning from any state that is not 'PUBLISHED' to nil", t, func() {
+		err := stateMachine.Transition(ctx, stateMachineBundleAPI, currentBundleWithStateDraft, nil)
+
+		Convey("Then the transition should not fail", func() {
+			So(err, ShouldBeNil)
+		})
+	})
 }
 
 func TestTransition_failure(t *testing.T) {
@@ -264,6 +273,15 @@ func TestTransition_failure(t *testing.T) {
 		Convey("Then the transition should fail", func() {
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldEqual, "bundle state must be DRAFT when creating a new bundle")
+		})
+	})
+
+	Convey("When transitioning from 'PUBLISHED' to nil", t, func() {
+		err := stateMachine.Transition(ctx, stateMachineBundleAPI, currentBundleWithStatePublished, nil)
+
+		Convey("Then the transition should fail", func() {
+			So(err, ShouldNotBeNil)
+			So(err.Error(), ShouldEqual, "cannot update a published bundle")
 		})
 	})
 }

--- a/features/bundles_delete.feature
+++ b/features/bundles_delete.feature
@@ -112,15 +112,15 @@ Feature: Delete a bundle and all its associated content items - DELETE /bundles/
         Given I am an admin user
         When I DELETE "/bundles/bundle-with-content-items"
         Then the HTTP status code should be "204"
-        And the content item in the database for id "content-item-1" should not exist
-        And the content item in the database for id "content-item-2" should not exist
-        And the bundle in the database for id "bundle-with-content-items" should not exist
+        And the record with id "content-item-1" should not exist in the "bundle_contents" collection
+        And the record with id "content-item-2" should not exist in the "bundle_contents" collection
+        And the record with id "bundle-with-content-items" should not exist in the "bundles" collection
     
     Scenario: DELETE /bundles/{bundle-id} successfully with a bundle that has no contents
         Given I am an admin user
         When I DELETE "/bundles/bundle-without-content-items"
         Then the HTTP status code should be "204"
-        And the bundle in the database for id "bundle-without-content-items" should not exist
+        And the record with id "bundle-without-content-items" should not exist in the "bundles" collection
 
     Scenario: DELETE /bundles/{bundle-id} with non-existent bundle
         Given I am an admin user

--- a/features/bundles_delete.feature
+++ b/features/bundles_delete.feature
@@ -1,0 +1,159 @@
+Feature: Delete a bundle and all its associated content items - DELETE /bundles/{bundle-id}
+
+    Background:
+        Given I have these bundles:
+        """
+        [
+            {
+                "id": "bundle-with-content-items",
+                "bundle_type": "SCHEDULED",
+                "created_by": {
+                    "email": "publisher@ons.gov.uk"
+                },
+                "created_at": "2025-01-01T07:00:00Z",
+                "last_updated_by": {
+                    "email": "publisher@ons.gov.uk"
+                },
+                "preview_teams": [
+                    {
+                        "id": "890m231k-98df-11ec-b909-0242ac120002"
+                    }
+                ],
+                "scheduled_at": "2025-01-03T07:00:00Z",
+                "state": "DRAFT",
+                "title": "bundle-with-content-items",
+                "updated_at": "2025-01-02T07:00:00Z",
+                "managed_by": "WAGTAIL",
+                "e_tag": "original-etag"
+            },
+            {
+                "id": "bundle-without-content-items",
+                "bundle_type": "SCHEDULED",
+                "created_by": {
+                    "email": "publisher@ons.gov.uk"
+                },
+                "created_at": "2025-01-04T07:00:00Z",
+                "last_updated_by": {
+                    "email": "publisher@ons.gov.uk"
+                },
+                "preview_teams": [
+                    {
+                        "id": "890m231k-98df-11ec-b909-0242ac120002"
+                    }
+                ],
+                "scheduled_at": "2025-01-06T07:00:00Z",
+                "state": "DRAFT",
+                "title": "bundle-without-content-items",
+                "updated_at": "2025-01-06T07:00:00Z",
+                "managed_by": "WAGTAIL",
+                "e_tag": "original-etag"
+            },
+            {
+                "id": "bundle-published",
+                "bundle_type": "SCHEDULED",
+                "created_by": {
+                    "email": "publisher@ons.gov.uk"
+                },
+                "created_at": "2025-01-04T07:00:00Z",
+                "last_updated_by": {
+                    "email": "publisher@ons.gov.uk"
+                },
+                "preview_teams": [
+                    {
+                        "id": "890m231k-98df-11ec-b909-0242ac120002"
+                    }
+                ],
+                "scheduled_at": "2025-01-06T07:00:00Z",
+                "state": "PUBLISHED",
+                "title": "bundle-published",
+                "updated_at": "2025-01-06T07:00:00Z",
+                "managed_by": "WAGTAIL",
+                "e_tag": "original-etag"
+            }
+        ]
+        """
+        And I have these content items:
+        """
+        [
+            {
+                "id": "content-item-1",
+                "bundle_id": "bundle-with-content-items",
+                "content_type": "DATASET",
+                "metadata": {
+                    "dataset_id": "dataset1",
+                    "edition_id": "edition1",
+                    "version_id": 1,
+                    "title": "Test Dataset 1"
+                },
+                "links": {
+                    "edit": "edit/link",
+                    "preview": "preview/link"
+                }
+            },
+            {
+                "id": "content-item-2",
+                "bundle_id": "bundle-with-content-items",
+                "content_type": "DATASET",
+                "metadata": {
+                    "dataset_id": "dataset2",
+                    "edition_id": "edition2",
+                    "version_id": 2,
+                    "title": "Test Dataset 2"
+                },
+                "links": {
+                    "edit": "edit/link",
+                    "preview": "preview/link"
+                }
+            }
+        ]
+        """
+
+    Scenario: DELETE /bundles/{bundle-id} successfully with a bundle that has contents
+        Given I am an admin user
+        When I DELETE "/bundles/bundle-with-content-items"
+        Then the HTTP status code should be "204"
+        And the content item in the database for id "content-item-1" should not exist
+        And the content item in the database for id "content-item-2" should not exist
+        And the bundle in the database for id "bundle-with-content-items" should not exist
+    
+    Scenario: DELETE /bundles/{bundle-id} successfully with a bundle that has no contents
+        Given I am an admin user
+        When I DELETE "/bundles/bundle-without-content-items"
+        Then the HTTP status code should be "204"
+        And the bundle in the database for id "bundle-without-content-items" should not exist
+
+    Scenario: DELETE /bundles/{bundle-id} with non-existent bundle
+        Given I am an admin user
+        When I DELETE "/bundles/missing-bundle"
+        Then I should receive the following JSON response with status "404":
+            """
+            {
+                "errors": [
+                    {
+                        "code": "not_found",
+                        "description": "The requested resource does not exist"
+                    }
+                ]
+            }
+            """
+    
+    Scenario: DELETE /bundles/{bundle-id} with a published bundle
+        Given I am an admin user
+        When I DELETE "/bundles/bundle-published"
+        Then I should receive the following JSON response with status "409":
+            """
+            {
+                "errors": [
+                    {
+                        "code": "conflict",
+                        "description": "Change rejected due to a conflict with the current resource state. A common cause is attempting to change a bundle that is already locked pending publication or has already been published."
+                    }
+                ]
+            }
+            """
+    
+    Scenario: DELETE /bundles/{bundle-id} with no authentication
+        Given I am not authenticated
+        When I DELETE "/bundles/bundle-with-content-items"
+        Then the HTTP status code should be "401"
+        And the response body should be empty

--- a/features/contents_delete.feature
+++ b/features/contents_delete.feature
@@ -91,7 +91,7 @@ Feature: Delete a content item from a bundle - POST /bundles/{bundle-id}/content
         Given I am an admin user
         When I DELETE "/bundles/bundle-1/contents/content-item-1"
         Then the HTTP status code should be "204"
-        And the content item in the database for id "content-item-1" should not exist
+        And the record with id "content-item-1" should not exist in the "bundle_contents" collection
     
     Scenario: DELETE /bundles/{bundle-id}/contents/{content-id} with non-existent bundle
         Given I am an admin user

--- a/mongo/bundle_contents_store.go
+++ b/mongo/bundle_contents_store.go
@@ -102,6 +102,21 @@ func (m *Mongo) ListBundleContents(ctx context.Context, bundleID string, offset,
 	return results, totalCount, nil
 }
 
+func (m *Mongo) ListBundleContentsWithoutLimit(ctx context.Context, bundleID string) (contents []*models.ContentItem, totalCount int, err error) {
+	var results []*models.ContentItem
+
+	filter, sort := buildListBundleContentsQuery(bundleID)
+
+	totalCount, err = m.Connection.Collection(m.ActualCollectionName(config.BundleContentsCollection)).
+		Find(ctx, filter, &results, mongodriver.Sort(sort))
+
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return results, totalCount, nil
+}
+
 func buildListBundleContentsQuery(bundleID string) (filter, sort bson.M) {
 	filter = bson.M{}
 

--- a/mongo/bundle_contents_store.go
+++ b/mongo/bundle_contents_store.go
@@ -142,13 +142,19 @@ func (m *Mongo) ListBundleContents(ctx context.Context, bundleID string, offset,
 	return results, totalCount, nil
 }
 
-func (m *Mongo) ListBundleContentsWithoutLimit(ctx context.Context, bundleID string) (contents []*models.ContentItem, err error) {
+func (m *Mongo) ListBundleContentIDsWithoutLimit(ctx context.Context, bundleID string) (contents []*models.ContentItem, err error) {
 	var results []*models.ContentItem
 
-	filter, sort := buildListBundleContentsQuery(bundleID)
+	filter := bson.M{
+		"bundle_id": bundleID,
+	}
+
+	projection := bson.M{
+		"id": 1,
+	}
 
 	_, err = m.Connection.Collection(m.ActualCollectionName(config.BundleContentsCollection)).
-		Find(ctx, filter, &results, mongodriver.Sort(sort))
+		Find(ctx, filter, &results, mongodriver.Projection(projection))
 
 	if err != nil {
 		return nil, err

--- a/mongo/bundle_contents_store.go
+++ b/mongo/bundle_contents_store.go
@@ -102,19 +102,19 @@ func (m *Mongo) ListBundleContents(ctx context.Context, bundleID string, offset,
 	return results, totalCount, nil
 }
 
-func (m *Mongo) ListBundleContentsWithoutLimit(ctx context.Context, bundleID string) (contents []*models.ContentItem, totalCount int, err error) {
+func (m *Mongo) ListBundleContentsWithoutLimit(ctx context.Context, bundleID string) (contents []*models.ContentItem, err error) {
 	var results []*models.ContentItem
 
 	filter, sort := buildListBundleContentsQuery(bundleID)
 
-	totalCount, err = m.Connection.Collection(m.ActualCollectionName(config.BundleContentsCollection)).
+	_, err = m.Connection.Collection(m.ActualCollectionName(config.BundleContentsCollection)).
 		Find(ctx, filter, &results, mongodriver.Sort(sort))
 
 	if err != nil {
-		return nil, 0, err
+		return nil, err
 	}
 
-	return results, totalCount, nil
+	return results, nil
 }
 
 func buildListBundleContentsQuery(bundleID string) (filter, sort bson.M) {

--- a/mongo/bundle_contents_store_test.go
+++ b/mongo/bundle_contents_store_test.go
@@ -402,11 +402,11 @@ func TestListBundleContentsWithoutLimit_Success(t *testing.T) {
 
 		Convey("When ListBundleContentsWithoutLimit is called with a valid bundle ID", func() {
 			bundleID := "bundle1"
-			contents, totalCount, err := mongodb.ListBundleContentsWithoutLimit(ctx, bundleID)
+			contents, err := mongodb.ListBundleContentsWithoutLimit(ctx, bundleID)
 
 			Convey("Then it returns the contents and total count without error", func() {
 				So(err, ShouldBeNil)
-				So(totalCount, ShouldEqual, 2)
+				So(len(contents), ShouldEqual, 2)
 				So(contents, ShouldHaveLength, 2)
 				So(contents[0].BundleID, ShouldEqual, bundleID)
 				So(contents[1].BundleID, ShouldEqual, bundleID)
@@ -427,11 +427,11 @@ func TestListBundleContentsWithoutLimit_Failure(t *testing.T) {
 
 		Convey("When ListBundleContentsWithoutLimit is called with a non-existent bundle ID", func() {
 			bundleID := "non-existent-bundle"
-			contents, totalCount, err := mongodb.ListBundleContentsWithoutLimit(ctx, bundleID)
+			contents, err := mongodb.ListBundleContentsWithoutLimit(ctx, bundleID)
 
 			Convey("Then it returns an empty list and zero count without error", func() {
 				So(err, ShouldBeNil)
-				So(totalCount, ShouldEqual, 0)
+				So(len(contents), ShouldEqual, 0)
 				So(contents, ShouldHaveLength, 0)
 			})
 		})
@@ -439,7 +439,7 @@ func TestListBundleContentsWithoutLimit_Failure(t *testing.T) {
 		Convey("When ListBundleContentsWithoutLimit is called and the connection is closed", func() {
 			mongodb.Connection.Close(ctx)
 			bundleID := "bundle1"
-			_, _, err := mongodb.ListBundleContentsWithoutLimit(ctx, bundleID)
+			_, err := mongodb.ListBundleContentsWithoutLimit(ctx, bundleID)
 
 			Convey("Then it returns an error", func() {
 				So(err, ShouldNotBeNil)

--- a/mongo/bundle_contents_store_test.go
+++ b/mongo/bundle_contents_store_test.go
@@ -480,7 +480,7 @@ func TestGetBundleContentsForBundle(t *testing.T) {
 	})
 }
 
-func TestListBundleContentsWithoutLimit_Success(t *testing.T) {
+func TestListBundleContentIDsWithoutLimit_Success(t *testing.T) {
 	ctx := context.Background()
 
 	Convey("Given the db connection is initialized correctly", t, func() {
@@ -490,22 +490,21 @@ func TestListBundleContentsWithoutLimit_Success(t *testing.T) {
 		err = setupBundleContentsTestData(ctx, mongodb)
 		So(err, ShouldBeNil)
 
-		Convey("When ListBundleContentsWithoutLimit is called with a valid bundle ID", func() {
+		Convey("When ListBundleContentIDsWithoutLimit is called with a valid bundle ID", func() {
 			bundleID := "bundle1"
-			contents, err := mongodb.ListBundleContentsWithoutLimit(ctx, bundleID)
+			contents, err := mongodb.ListBundleContentIDsWithoutLimit(ctx, bundleID)
 
 			Convey("Then it returns the contents and total count without error", func() {
 				So(err, ShouldBeNil)
-				So(len(contents), ShouldEqual, 2)
 				So(contents, ShouldHaveLength, 2)
-				So(contents[0].BundleID, ShouldEqual, bundleID)
-				So(contents[1].BundleID, ShouldEqual, bundleID)
+				So(contents[0].ID, ShouldEqual, contentsTestData[0].ID)
+				So(contents[1].ID, ShouldEqual, contentsTestData[1].ID)
 			})
 		})
 	})
 }
 
-func TestListBundleContentsWithoutLimit_Failure(t *testing.T) {
+func TestListBundleContentIDsWithoutLimit_Failure(t *testing.T) {
 	ctx := context.Background()
 
 	Convey("Given the db connection is initialized correctly", t, func() {
@@ -515,9 +514,9 @@ func TestListBundleContentsWithoutLimit_Failure(t *testing.T) {
 		err = setupBundleContentsTestData(ctx, mongodb)
 		So(err, ShouldBeNil)
 
-		Convey("When ListBundleContentsWithoutLimit is called with a non-existent bundle ID", func() {
+		Convey("When ListBundleContentIDsWithoutLimit is called with a non-existent bundle ID", func() {
 			bundleID := "non-existent-bundle"
-			contents, err := mongodb.ListBundleContentsWithoutLimit(ctx, bundleID)
+			contents, err := mongodb.ListBundleContentIDsWithoutLimit(ctx, bundleID)
 
 			Convey("Then it returns an empty list and zero count without error", func() {
 				So(err, ShouldBeNil)
@@ -526,10 +525,10 @@ func TestListBundleContentsWithoutLimit_Failure(t *testing.T) {
 			})
 		})
 
-		Convey("When ListBundleContentsWithoutLimit is called and the connection is closed", func() {
+		Convey("When ListBundleContentIDsWithoutLimit is called and the connection is closed", func() {
 			mongodb.Connection.Close(ctx)
 			bundleID := "bundle1"
-			_, err := mongodb.ListBundleContentsWithoutLimit(ctx, bundleID)
+			_, err := mongodb.ListBundleContentIDsWithoutLimit(ctx, bundleID)
 
 			Convey("Then it returns an error", func() {
 				So(err, ShouldNotBeNil)

--- a/store/datastore.go
+++ b/store/datastore.go
@@ -33,7 +33,7 @@ type dataMongoDB interface {
 	CheckContentItemExistsByDatasetEditionVersion(ctx context.Context, datasetID, editionID string, versionID int) (bool, error)
 	DeleteContentItem(ctx context.Context, contentItemID string) error
 	ListBundleContents(ctx context.Context, bundleID string, offset, limit int) ([]*models.ContentItem, int, error)
-	ListBundleContentsWithoutLimit(ctx context.Context, bundleID string) (contents []*models.ContentItem, totalCount int, err error)
+	ListBundleContentsWithoutLimit(ctx context.Context, bundleID string) (contents []*models.ContentItem, err error)
 	CreateBundleEvent(ctx context.Context, event *models.Event) error
 	Checker(ctx context.Context, state *healthcheck.CheckState) error
 	Close(ctx context.Context) error
@@ -110,6 +110,6 @@ func (ds *Datastore) ListBundleContents(ctx context.Context, bundleID string, of
 	return ds.Backend.ListBundleContents(ctx, bundleID, offset, limit)
 }
 
-func (ds *Datastore) ListBundleContentsWithoutLimit(ctx context.Context, bundleID string) ([]*models.ContentItem, int, error) {
+func (ds *Datastore) ListBundleContentsWithoutLimit(ctx context.Context, bundleID string) ([]*models.ContentItem, error) {
 	return ds.Backend.ListBundleContentsWithoutLimit(ctx, bundleID)
 }

--- a/store/datastore.go
+++ b/store/datastore.go
@@ -31,6 +31,8 @@ type dataMongoDB interface {
 	UpdateBundle(ctx context.Context, id string, update *models.Bundle) (*models.Bundle, error)
 
 	// Content items
+	ListBundleContents(ctx context.Context, bundleID string, offset, limit int) ([]*models.ContentItem, int, error)
+	ListBundleContentIDsWithoutLimit(ctx context.Context, bundleID string) (contents []*models.ContentItem, err error)
 	GetContentItemByBundleIDAndContentItemID(ctx context.Context, bundleID, contentItemID string) (*models.ContentItem, error)
 	CreateContentItem(ctx context.Context, contentItem *models.ContentItem) error
 	CheckAllBundleContentsAreApproved(ctx context.Context, bundleID string) (bool, error)
@@ -40,8 +42,6 @@ type dataMongoDB interface {
 	UpdateContentItemState(ctx context.Context, contentItemID, state string) error
 
 	// Events
-	ListBundleContents(ctx context.Context, bundleID string, offset, limit int) ([]*models.ContentItem, int, error)
-	ListBundleContentsWithoutLimit(ctx context.Context, bundleID string) (contents []*models.ContentItem, err error)
 	CreateBundleEvent(ctx context.Context, event *models.Event) error
 
 	// Other
@@ -132,6 +132,6 @@ func (ds *Datastore) ListBundleContents(ctx context.Context, bundleID string, of
 	return ds.Backend.ListBundleContents(ctx, bundleID, offset, limit)
 }
 
-func (ds *Datastore) ListBundleContentsWithoutLimit(ctx context.Context, bundleID string) ([]*models.ContentItem, error) {
-	return ds.Backend.ListBundleContentsWithoutLimit(ctx, bundleID)
+func (ds *Datastore) ListBundleContentIDsWithoutLimit(ctx context.Context, bundleID string) ([]*models.ContentItem, error) {
+	return ds.Backend.ListBundleContentIDsWithoutLimit(ctx, bundleID)
 }

--- a/store/datastore.go
+++ b/store/datastore.go
@@ -23,6 +23,7 @@ type dataMongoDB interface {
 	ListBundleEvents(ctx context.Context, offset, limit int, bundleID string, after, before *time.Time) ([]*models.Event, int, error)
 	GetBundle(ctx context.Context, bundleID string) (*models.Bundle, error)
 	CreateBundle(ctx context.Context, bundle *models.Bundle) error
+	DeleteBundle(ctx context.Context, id string) (err error)
 	CheckBundleExistsByTitle(ctx context.Context, title string) (bool, error)
 	UpdateBundleETag(ctx context.Context, bundleID, email string) (*models.Bundle, error)
 	CheckBundleExists(ctx context.Context, bundleID string) (bool, error)
@@ -32,6 +33,7 @@ type dataMongoDB interface {
 	CheckContentItemExistsByDatasetEditionVersion(ctx context.Context, datasetID, editionID string, versionID int) (bool, error)
 	DeleteContentItem(ctx context.Context, contentItemID string) error
 	ListBundleContents(ctx context.Context, bundleID string, offset, limit int) ([]*models.ContentItem, int, error)
+	ListBundleContentsWithoutLimit(ctx context.Context, bundleID string) (contents []*models.ContentItem, totalCount int, err error)
 	CreateBundleEvent(ctx context.Context, event *models.Event) error
 	Checker(ctx context.Context, state *healthcheck.CheckState) error
 	Close(ctx context.Context) error
@@ -62,6 +64,10 @@ func (ds *Datastore) GetBundle(ctx context.Context, bundleID string) (*models.Bu
 
 func (ds *Datastore) CreateBundle(ctx context.Context, bundle *models.Bundle) error {
 	return ds.Backend.CreateBundle(ctx, bundle)
+}
+
+func (ds *Datastore) DeleteBundle(ctx context.Context, id string) (err error) {
+	return ds.Backend.DeleteBundle(ctx, id)
 }
 
 func (ds *Datastore) UpdateBundleETag(ctx context.Context, bundleID, email string) (*models.Bundle, error) {
@@ -102,4 +108,8 @@ func (ds *Datastore) CheckBundleExistsByTitle(ctx context.Context, title string)
 
 func (ds *Datastore) ListBundleContents(ctx context.Context, bundleID string, offset, limit int) ([]*models.ContentItem, int, error) {
 	return ds.Backend.ListBundleContents(ctx, bundleID, offset, limit)
+}
+
+func (ds *Datastore) ListBundleContentsWithoutLimit(ctx context.Context, bundleID string) ([]*models.ContentItem, int, error) {
+	return ds.Backend.ListBundleContentsWithoutLimit(ctx, bundleID)
 }

--- a/store/datastoretest/datastore.go
+++ b/store/datastoretest/datastore.go
@@ -65,11 +65,11 @@ var _ store.Storer = &StorerMock{}
 //			GetContentItemByBundleIDAndContentItemIDFunc: func(ctx context.Context, bundleID string, contentItemID string) (*models.ContentItem, error) {
 //				panic("mock out the GetContentItemByBundleIDAndContentItemID method")
 //			},
+//			ListBundleContentIDsWithoutLimitFunc: func(ctx context.Context, bundleID string) ([]*models.ContentItem, error) {
+//				panic("mock out the ListBundleContentIDsWithoutLimit method")
+//			},
 //			ListBundleContentsFunc: func(ctx context.Context, bundleID string, offset int, limit int) ([]*models.ContentItem, int, error) {
 //				panic("mock out the ListBundleContents method")
-//			},
-//			ListBundleContentsWithoutLimitFunc: func(ctx context.Context, bundleID string) ([]*models.ContentItem, error) {
-//				panic("mock out the ListBundleContentsWithoutLimit method")
 //			},
 //			ListBundleEventsFunc: func(ctx context.Context, offset int, limit int, bundleID string, after *time.Time, before *time.Time) ([]*models.Event, int, error) {
 //				panic("mock out the ListBundleEvents method")
@@ -135,11 +135,11 @@ type StorerMock struct {
 	// GetContentItemByBundleIDAndContentItemIDFunc mocks the GetContentItemByBundleIDAndContentItemID method.
 	GetContentItemByBundleIDAndContentItemIDFunc func(ctx context.Context, bundleID string, contentItemID string) (*models.ContentItem, error)
 
+	// ListBundleContentIDsWithoutLimitFunc mocks the ListBundleContentIDsWithoutLimit method.
+	ListBundleContentIDsWithoutLimitFunc func(ctx context.Context, bundleID string) ([]*models.ContentItem, error)
+
 	// ListBundleContentsFunc mocks the ListBundleContents method.
 	ListBundleContentsFunc func(ctx context.Context, bundleID string, offset int, limit int) ([]*models.ContentItem, int, error)
-
-	// ListBundleContentsWithoutLimitFunc mocks the ListBundleContentsWithoutLimit method.
-	ListBundleContentsWithoutLimitFunc func(ctx context.Context, bundleID string) ([]*models.ContentItem, error)
 
 	// ListBundleEventsFunc mocks the ListBundleEvents method.
 	ListBundleEventsFunc func(ctx context.Context, offset int, limit int, bundleID string, after *time.Time, before *time.Time) ([]*models.Event, int, error)
@@ -260,6 +260,13 @@ type StorerMock struct {
 			// ContentItemID is the contentItemID argument value.
 			ContentItemID string
 		}
+		// ListBundleContentIDsWithoutLimit holds details about calls to the ListBundleContentIDsWithoutLimit method.
+		ListBundleContentIDsWithoutLimit []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// BundleID is the bundleID argument value.
+			BundleID string
+		}
 		// ListBundleContents holds details about calls to the ListBundleContents method.
 		ListBundleContents []struct {
 			// Ctx is the ctx argument value.
@@ -270,13 +277,6 @@ type StorerMock struct {
 			Offset int
 			// Limit is the limit argument value.
 			Limit int
-		}
-		// ListBundleContentsWithoutLimit holds details about calls to the ListBundleContentsWithoutLimit method.
-		ListBundleContentsWithoutLimit []struct {
-			// Ctx is the ctx argument value.
-			Ctx context.Context
-			// BundleID is the bundleID argument value.
-			BundleID string
 		}
 		// ListBundleEvents holds details about calls to the ListBundleEvents method.
 		ListBundleEvents []struct {
@@ -346,8 +346,8 @@ type StorerMock struct {
 	lockGetBundle                                     sync.RWMutex
 	lockGetBundleContentsForBundle                    sync.RWMutex
 	lockGetContentItemByBundleIDAndContentItemID      sync.RWMutex
+	lockListBundleContentIDsWithoutLimit              sync.RWMutex
 	lockListBundleContents                            sync.RWMutex
-	lockListBundleContentsWithoutLimit                sync.RWMutex
 	lockListBundleEvents                              sync.RWMutex
 	lockListBundles                                   sync.RWMutex
 	lockUpdateBundle                                  sync.RWMutex
@@ -867,6 +867,42 @@ func (mock *StorerMock) GetContentItemByBundleIDAndContentItemIDCalls() []struct
 	return calls
 }
 
+// ListBundleContentIDsWithoutLimit calls ListBundleContentIDsWithoutLimitFunc.
+func (mock *StorerMock) ListBundleContentIDsWithoutLimit(ctx context.Context, bundleID string) ([]*models.ContentItem, error) {
+	if mock.ListBundleContentIDsWithoutLimitFunc == nil {
+		panic("StorerMock.ListBundleContentIDsWithoutLimitFunc: method is nil but Storer.ListBundleContentIDsWithoutLimit was just called")
+	}
+	callInfo := struct {
+		Ctx      context.Context
+		BundleID string
+	}{
+		Ctx:      ctx,
+		BundleID: bundleID,
+	}
+	mock.lockListBundleContentIDsWithoutLimit.Lock()
+	mock.calls.ListBundleContentIDsWithoutLimit = append(mock.calls.ListBundleContentIDsWithoutLimit, callInfo)
+	mock.lockListBundleContentIDsWithoutLimit.Unlock()
+	return mock.ListBundleContentIDsWithoutLimitFunc(ctx, bundleID)
+}
+
+// ListBundleContentIDsWithoutLimitCalls gets all the calls that were made to ListBundleContentIDsWithoutLimit.
+// Check the length with:
+//
+//	len(mockedStorer.ListBundleContentIDsWithoutLimitCalls())
+func (mock *StorerMock) ListBundleContentIDsWithoutLimitCalls() []struct {
+	Ctx      context.Context
+	BundleID string
+} {
+	var calls []struct {
+		Ctx      context.Context
+		BundleID string
+	}
+	mock.lockListBundleContentIDsWithoutLimit.RLock()
+	calls = mock.calls.ListBundleContentIDsWithoutLimit
+	mock.lockListBundleContentIDsWithoutLimit.RUnlock()
+	return calls
+}
+
 // ListBundleContents calls ListBundleContentsFunc.
 func (mock *StorerMock) ListBundleContents(ctx context.Context, bundleID string, offset int, limit int) ([]*models.ContentItem, int, error) {
 	if mock.ListBundleContentsFunc == nil {
@@ -908,42 +944,6 @@ func (mock *StorerMock) ListBundleContentsCalls() []struct {
 	mock.lockListBundleContents.RLock()
 	calls = mock.calls.ListBundleContents
 	mock.lockListBundleContents.RUnlock()
-	return calls
-}
-
-// ListBundleContentsWithoutLimit calls ListBundleContentsWithoutLimitFunc.
-func (mock *StorerMock) ListBundleContentsWithoutLimit(ctx context.Context, bundleID string) ([]*models.ContentItem, error) {
-	if mock.ListBundleContentsWithoutLimitFunc == nil {
-		panic("StorerMock.ListBundleContentsWithoutLimitFunc: method is nil but Storer.ListBundleContentsWithoutLimit was just called")
-	}
-	callInfo := struct {
-		Ctx      context.Context
-		BundleID string
-	}{
-		Ctx:      ctx,
-		BundleID: bundleID,
-	}
-	mock.lockListBundleContentsWithoutLimit.Lock()
-	mock.calls.ListBundleContentsWithoutLimit = append(mock.calls.ListBundleContentsWithoutLimit, callInfo)
-	mock.lockListBundleContentsWithoutLimit.Unlock()
-	return mock.ListBundleContentsWithoutLimitFunc(ctx, bundleID)
-}
-
-// ListBundleContentsWithoutLimitCalls gets all the calls that were made to ListBundleContentsWithoutLimit.
-// Check the length with:
-//
-//	len(mockedStorer.ListBundleContentsWithoutLimitCalls())
-func (mock *StorerMock) ListBundleContentsWithoutLimitCalls() []struct {
-	Ctx      context.Context
-	BundleID string
-} {
-	var calls []struct {
-		Ctx      context.Context
-		BundleID string
-	}
-	mock.lockListBundleContentsWithoutLimit.RLock()
-	calls = mock.calls.ListBundleContentsWithoutLimit
-	mock.lockListBundleContentsWithoutLimit.RUnlock()
 	return calls
 }
 

--- a/store/datastoretest/datastore.go
+++ b/store/datastoretest/datastore.go
@@ -65,7 +65,7 @@ var _ store.Storer = &StorerMock{}
 //			ListBundleContentsFunc: func(ctx context.Context, bundleID string, offset int, limit int) ([]*models.ContentItem, int, error) {
 //				panic("mock out the ListBundleContents method")
 //			},
-//			ListBundleContentsWithoutLimitFunc: func(ctx context.Context, bundleID string) ([]*models.ContentItem, int, error) {
+//			ListBundleContentsWithoutLimitFunc: func(ctx context.Context, bundleID string) ([]*models.ContentItem, error) {
 //				panic("mock out the ListBundleContentsWithoutLimit method")
 //			},
 //			ListBundleEventsFunc: func(ctx context.Context, offset int, limit int, bundleID string, after *time.Time, before *time.Time) ([]*models.Event, int, error) {
@@ -127,7 +127,7 @@ type StorerMock struct {
 	ListBundleContentsFunc func(ctx context.Context, bundleID string, offset int, limit int) ([]*models.ContentItem, int, error)
 
 	// ListBundleContentsWithoutLimitFunc mocks the ListBundleContentsWithoutLimit method.
-	ListBundleContentsWithoutLimitFunc func(ctx context.Context, bundleID string) ([]*models.ContentItem, int, error)
+	ListBundleContentsWithoutLimitFunc func(ctx context.Context, bundleID string) ([]*models.ContentItem, error)
 
 	// ListBundleEventsFunc mocks the ListBundleEvents method.
 	ListBundleEventsFunc func(ctx context.Context, offset int, limit int, bundleID string, after *time.Time, before *time.Time) ([]*models.Event, int, error)
@@ -830,7 +830,7 @@ func (mock *StorerMock) ListBundleContentsCalls() []struct {
 }
 
 // ListBundleContentsWithoutLimit calls ListBundleContentsWithoutLimitFunc.
-func (mock *StorerMock) ListBundleContentsWithoutLimit(ctx context.Context, bundleID string) ([]*models.ContentItem, int, error) {
+func (mock *StorerMock) ListBundleContentsWithoutLimit(ctx context.Context, bundleID string) ([]*models.ContentItem, error) {
 	if mock.ListBundleContentsWithoutLimitFunc == nil {
 		panic("StorerMock.ListBundleContentsWithoutLimitFunc: method is nil but Storer.ListBundleContentsWithoutLimit was just called")
 	}

--- a/store/datastoretest/mongo.go
+++ b/store/datastoretest/mongo.go
@@ -65,7 +65,7 @@ var _ store.MongoDB = &MongoDBMock{}
 //			ListBundleContentsFunc: func(ctx context.Context, bundleID string, offset int, limit int) ([]*models.ContentItem, int, error) {
 //				panic("mock out the ListBundleContents method")
 //			},
-//			ListBundleContentsWithoutLimitFunc: func(ctx context.Context, bundleID string) ([]*models.ContentItem, int, error) {
+//			ListBundleContentsWithoutLimitFunc: func(ctx context.Context, bundleID string) ([]*models.ContentItem, error) {
 //				panic("mock out the ListBundleContentsWithoutLimit method")
 //			},
 //			ListBundleEventsFunc: func(ctx context.Context, offset int, limit int, bundleID string, after *time.Time, before *time.Time) ([]*models.Event, int, error) {
@@ -127,7 +127,7 @@ type MongoDBMock struct {
 	ListBundleContentsFunc func(ctx context.Context, bundleID string, offset int, limit int) ([]*models.ContentItem, int, error)
 
 	// ListBundleContentsWithoutLimitFunc mocks the ListBundleContentsWithoutLimit method.
-	ListBundleContentsWithoutLimitFunc func(ctx context.Context, bundleID string) ([]*models.ContentItem, int, error)
+	ListBundleContentsWithoutLimitFunc func(ctx context.Context, bundleID string) ([]*models.ContentItem, error)
 
 	// ListBundleEventsFunc mocks the ListBundleEvents method.
 	ListBundleEventsFunc func(ctx context.Context, offset int, limit int, bundleID string, after *time.Time, before *time.Time) ([]*models.Event, int, error)
@@ -830,7 +830,7 @@ func (mock *MongoDBMock) ListBundleContentsCalls() []struct {
 }
 
 // ListBundleContentsWithoutLimit calls ListBundleContentsWithoutLimitFunc.
-func (mock *MongoDBMock) ListBundleContentsWithoutLimit(ctx context.Context, bundleID string) ([]*models.ContentItem, int, error) {
+func (mock *MongoDBMock) ListBundleContentsWithoutLimit(ctx context.Context, bundleID string) ([]*models.ContentItem, error) {
 	if mock.ListBundleContentsWithoutLimitFunc == nil {
 		panic("MongoDBMock.ListBundleContentsWithoutLimitFunc: method is nil but MongoDB.ListBundleContentsWithoutLimit was just called")
 	}

--- a/store/datastoretest/mongo.go
+++ b/store/datastoretest/mongo.go
@@ -65,11 +65,11 @@ var _ store.MongoDB = &MongoDBMock{}
 //			GetContentItemByBundleIDAndContentItemIDFunc: func(ctx context.Context, bundleID string, contentItemID string) (*models.ContentItem, error) {
 //				panic("mock out the GetContentItemByBundleIDAndContentItemID method")
 //			},
+//			ListBundleContentIDsWithoutLimitFunc: func(ctx context.Context, bundleID string) ([]*models.ContentItem, error) {
+//				panic("mock out the ListBundleContentIDsWithoutLimit method")
+//			},
 //			ListBundleContentsFunc: func(ctx context.Context, bundleID string, offset int, limit int) ([]*models.ContentItem, int, error) {
 //				panic("mock out the ListBundleContents method")
-//			},
-//			ListBundleContentsWithoutLimitFunc: func(ctx context.Context, bundleID string) ([]*models.ContentItem, error) {
-//				panic("mock out the ListBundleContentsWithoutLimit method")
 //			},
 //			ListBundleEventsFunc: func(ctx context.Context, offset int, limit int, bundleID string, after *time.Time, before *time.Time) ([]*models.Event, int, error) {
 //				panic("mock out the ListBundleEvents method")
@@ -135,11 +135,11 @@ type MongoDBMock struct {
 	// GetContentItemByBundleIDAndContentItemIDFunc mocks the GetContentItemByBundleIDAndContentItemID method.
 	GetContentItemByBundleIDAndContentItemIDFunc func(ctx context.Context, bundleID string, contentItemID string) (*models.ContentItem, error)
 
+	// ListBundleContentIDsWithoutLimitFunc mocks the ListBundleContentIDsWithoutLimit method.
+	ListBundleContentIDsWithoutLimitFunc func(ctx context.Context, bundleID string) ([]*models.ContentItem, error)
+
 	// ListBundleContentsFunc mocks the ListBundleContents method.
 	ListBundleContentsFunc func(ctx context.Context, bundleID string, offset int, limit int) ([]*models.ContentItem, int, error)
-
-	// ListBundleContentsWithoutLimitFunc mocks the ListBundleContentsWithoutLimit method.
-	ListBundleContentsWithoutLimitFunc func(ctx context.Context, bundleID string) ([]*models.ContentItem, error)
 
 	// ListBundleEventsFunc mocks the ListBundleEvents method.
 	ListBundleEventsFunc func(ctx context.Context, offset int, limit int, bundleID string, after *time.Time, before *time.Time) ([]*models.Event, int, error)
@@ -260,6 +260,13 @@ type MongoDBMock struct {
 			// ContentItemID is the contentItemID argument value.
 			ContentItemID string
 		}
+		// ListBundleContentIDsWithoutLimit holds details about calls to the ListBundleContentIDsWithoutLimit method.
+		ListBundleContentIDsWithoutLimit []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// BundleID is the bundleID argument value.
+			BundleID string
+		}
 		// ListBundleContents holds details about calls to the ListBundleContents method.
 		ListBundleContents []struct {
 			// Ctx is the ctx argument value.
@@ -270,13 +277,6 @@ type MongoDBMock struct {
 			Offset int
 			// Limit is the limit argument value.
 			Limit int
-		}
-		// ListBundleContentsWithoutLimit holds details about calls to the ListBundleContentsWithoutLimit method.
-		ListBundleContentsWithoutLimit []struct {
-			// Ctx is the ctx argument value.
-			Ctx context.Context
-			// BundleID is the bundleID argument value.
-			BundleID string
 		}
 		// ListBundleEvents holds details about calls to the ListBundleEvents method.
 		ListBundleEvents []struct {
@@ -346,8 +346,8 @@ type MongoDBMock struct {
 	lockGetBundle                                     sync.RWMutex
 	lockGetBundleContentsForBundle                    sync.RWMutex
 	lockGetContentItemByBundleIDAndContentItemID      sync.RWMutex
+	lockListBundleContentIDsWithoutLimit              sync.RWMutex
 	lockListBundleContents                            sync.RWMutex
-	lockListBundleContentsWithoutLimit                sync.RWMutex
 	lockListBundleEvents                              sync.RWMutex
 	lockListBundles                                   sync.RWMutex
 	lockUpdateBundle                                  sync.RWMutex
@@ -867,6 +867,42 @@ func (mock *MongoDBMock) GetContentItemByBundleIDAndContentItemIDCalls() []struc
 	return calls
 }
 
+// ListBundleContentIDsWithoutLimit calls ListBundleContentIDsWithoutLimitFunc.
+func (mock *MongoDBMock) ListBundleContentIDsWithoutLimit(ctx context.Context, bundleID string) ([]*models.ContentItem, error) {
+	if mock.ListBundleContentIDsWithoutLimitFunc == nil {
+		panic("MongoDBMock.ListBundleContentIDsWithoutLimitFunc: method is nil but MongoDB.ListBundleContentIDsWithoutLimit was just called")
+	}
+	callInfo := struct {
+		Ctx      context.Context
+		BundleID string
+	}{
+		Ctx:      ctx,
+		BundleID: bundleID,
+	}
+	mock.lockListBundleContentIDsWithoutLimit.Lock()
+	mock.calls.ListBundleContentIDsWithoutLimit = append(mock.calls.ListBundleContentIDsWithoutLimit, callInfo)
+	mock.lockListBundleContentIDsWithoutLimit.Unlock()
+	return mock.ListBundleContentIDsWithoutLimitFunc(ctx, bundleID)
+}
+
+// ListBundleContentIDsWithoutLimitCalls gets all the calls that were made to ListBundleContentIDsWithoutLimit.
+// Check the length with:
+//
+//	len(mockedMongoDB.ListBundleContentIDsWithoutLimitCalls())
+func (mock *MongoDBMock) ListBundleContentIDsWithoutLimitCalls() []struct {
+	Ctx      context.Context
+	BundleID string
+} {
+	var calls []struct {
+		Ctx      context.Context
+		BundleID string
+	}
+	mock.lockListBundleContentIDsWithoutLimit.RLock()
+	calls = mock.calls.ListBundleContentIDsWithoutLimit
+	mock.lockListBundleContentIDsWithoutLimit.RUnlock()
+	return calls
+}
+
 // ListBundleContents calls ListBundleContentsFunc.
 func (mock *MongoDBMock) ListBundleContents(ctx context.Context, bundleID string, offset int, limit int) ([]*models.ContentItem, int, error) {
 	if mock.ListBundleContentsFunc == nil {
@@ -908,42 +944,6 @@ func (mock *MongoDBMock) ListBundleContentsCalls() []struct {
 	mock.lockListBundleContents.RLock()
 	calls = mock.calls.ListBundleContents
 	mock.lockListBundleContents.RUnlock()
-	return calls
-}
-
-// ListBundleContentsWithoutLimit calls ListBundleContentsWithoutLimitFunc.
-func (mock *MongoDBMock) ListBundleContentsWithoutLimit(ctx context.Context, bundleID string) ([]*models.ContentItem, error) {
-	if mock.ListBundleContentsWithoutLimitFunc == nil {
-		panic("MongoDBMock.ListBundleContentsWithoutLimitFunc: method is nil but MongoDB.ListBundleContentsWithoutLimit was just called")
-	}
-	callInfo := struct {
-		Ctx      context.Context
-		BundleID string
-	}{
-		Ctx:      ctx,
-		BundleID: bundleID,
-	}
-	mock.lockListBundleContentsWithoutLimit.Lock()
-	mock.calls.ListBundleContentsWithoutLimit = append(mock.calls.ListBundleContentsWithoutLimit, callInfo)
-	mock.lockListBundleContentsWithoutLimit.Unlock()
-	return mock.ListBundleContentsWithoutLimitFunc(ctx, bundleID)
-}
-
-// ListBundleContentsWithoutLimitCalls gets all the calls that were made to ListBundleContentsWithoutLimit.
-// Check the length with:
-//
-//	len(mockedMongoDB.ListBundleContentsWithoutLimitCalls())
-func (mock *MongoDBMock) ListBundleContentsWithoutLimitCalls() []struct {
-	Ctx      context.Context
-	BundleID string
-} {
-	var calls []struct {
-		Ctx      context.Context
-		BundleID string
-	}
-	mock.lockListBundleContentsWithoutLimit.RLock()
-	calls = mock.calls.ListBundleContentsWithoutLimit
-	mock.lockListBundleContentsWithoutLimit.RUnlock()
 	return calls
 }
 

--- a/store/datastoretest/mongo.go
+++ b/store/datastoretest/mongo.go
@@ -50,6 +50,9 @@ var _ store.MongoDB = &MongoDBMock{}
 //			CreateContentItemFunc: func(ctx context.Context, contentItem *models.ContentItem) error {
 //				panic("mock out the CreateContentItem method")
 //			},
+//			DeleteBundleFunc: func(ctx context.Context, id string) error {
+//				panic("mock out the DeleteBundle method")
+//			},
 //			DeleteContentItemFunc: func(ctx context.Context, contentItemID string) error {
 //				panic("mock out the DeleteContentItem method")
 //			},
@@ -61,6 +64,9 @@ var _ store.MongoDB = &MongoDBMock{}
 //			},
 //			ListBundleContentsFunc: func(ctx context.Context, bundleID string, offset int, limit int) ([]*models.ContentItem, int, error) {
 //				panic("mock out the ListBundleContents method")
+//			},
+//			ListBundleContentsWithoutLimitFunc: func(ctx context.Context, bundleID string) ([]*models.ContentItem, int, error) {
+//				panic("mock out the ListBundleContentsWithoutLimit method")
 //			},
 //			ListBundleEventsFunc: func(ctx context.Context, offset int, limit int, bundleID string, after *time.Time, before *time.Time) ([]*models.Event, int, error) {
 //				panic("mock out the ListBundleEvents method")
@@ -105,6 +111,9 @@ type MongoDBMock struct {
 	// CreateContentItemFunc mocks the CreateContentItem method.
 	CreateContentItemFunc func(ctx context.Context, contentItem *models.ContentItem) error
 
+	// DeleteBundleFunc mocks the DeleteBundle method.
+	DeleteBundleFunc func(ctx context.Context, id string) error
+
 	// DeleteContentItemFunc mocks the DeleteContentItem method.
 	DeleteContentItemFunc func(ctx context.Context, contentItemID string) error
 
@@ -116,6 +125,9 @@ type MongoDBMock struct {
 
 	// ListBundleContentsFunc mocks the ListBundleContents method.
 	ListBundleContentsFunc func(ctx context.Context, bundleID string, offset int, limit int) ([]*models.ContentItem, int, error)
+
+	// ListBundleContentsWithoutLimitFunc mocks the ListBundleContentsWithoutLimit method.
+	ListBundleContentsWithoutLimitFunc func(ctx context.Context, bundleID string) ([]*models.ContentItem, int, error)
 
 	// ListBundleEventsFunc mocks the ListBundleEvents method.
 	ListBundleEventsFunc func(ctx context.Context, offset int, limit int, bundleID string, after *time.Time, before *time.Time) ([]*models.Event, int, error)
@@ -193,6 +205,13 @@ type MongoDBMock struct {
 			// ContentItem is the contentItem argument value.
 			ContentItem *models.ContentItem
 		}
+		// DeleteBundle holds details about calls to the DeleteBundle method.
+		DeleteBundle []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// ID is the id argument value.
+			ID string
+		}
 		// DeleteContentItem holds details about calls to the DeleteContentItem method.
 		DeleteContentItem []struct {
 			// Ctx is the ctx argument value.
@@ -226,6 +245,13 @@ type MongoDBMock struct {
 			Offset int
 			// Limit is the limit argument value.
 			Limit int
+		}
+		// ListBundleContentsWithoutLimit holds details about calls to the ListBundleContentsWithoutLimit method.
+		ListBundleContentsWithoutLimit []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// BundleID is the bundleID argument value.
+			BundleID string
 		}
 		// ListBundleEvents holds details about calls to the ListBundleEvents method.
 		ListBundleEvents []struct {
@@ -272,10 +298,12 @@ type MongoDBMock struct {
 	lockCreateBundle                                  sync.RWMutex
 	lockCreateBundleEvent                             sync.RWMutex
 	lockCreateContentItem                             sync.RWMutex
+	lockDeleteBundle                                  sync.RWMutex
 	lockDeleteContentItem                             sync.RWMutex
 	lockGetBundle                                     sync.RWMutex
 	lockGetContentItemByBundleIDAndContentItemID      sync.RWMutex
 	lockListBundleContents                            sync.RWMutex
+	lockListBundleContentsWithoutLimit                sync.RWMutex
 	lockListBundleEvents                              sync.RWMutex
 	lockListBundles                                   sync.RWMutex
 	lockUpdateBundleETag                              sync.RWMutex
@@ -609,6 +637,42 @@ func (mock *MongoDBMock) CreateContentItemCalls() []struct {
 	return calls
 }
 
+// DeleteBundle calls DeleteBundleFunc.
+func (mock *MongoDBMock) DeleteBundle(ctx context.Context, id string) error {
+	if mock.DeleteBundleFunc == nil {
+		panic("MongoDBMock.DeleteBundleFunc: method is nil but MongoDB.DeleteBundle was just called")
+	}
+	callInfo := struct {
+		Ctx context.Context
+		ID  string
+	}{
+		Ctx: ctx,
+		ID:  id,
+	}
+	mock.lockDeleteBundle.Lock()
+	mock.calls.DeleteBundle = append(mock.calls.DeleteBundle, callInfo)
+	mock.lockDeleteBundle.Unlock()
+	return mock.DeleteBundleFunc(ctx, id)
+}
+
+// DeleteBundleCalls gets all the calls that were made to DeleteBundle.
+// Check the length with:
+//
+//	len(mockedMongoDB.DeleteBundleCalls())
+func (mock *MongoDBMock) DeleteBundleCalls() []struct {
+	Ctx context.Context
+	ID  string
+} {
+	var calls []struct {
+		Ctx context.Context
+		ID  string
+	}
+	mock.lockDeleteBundle.RLock()
+	calls = mock.calls.DeleteBundle
+	mock.lockDeleteBundle.RUnlock()
+	return calls
+}
+
 // DeleteContentItem calls DeleteContentItemFunc.
 func (mock *MongoDBMock) DeleteContentItem(ctx context.Context, contentItemID string) error {
 	if mock.DeleteContentItemFunc == nil {
@@ -762,6 +826,42 @@ func (mock *MongoDBMock) ListBundleContentsCalls() []struct {
 	mock.lockListBundleContents.RLock()
 	calls = mock.calls.ListBundleContents
 	mock.lockListBundleContents.RUnlock()
+	return calls
+}
+
+// ListBundleContentsWithoutLimit calls ListBundleContentsWithoutLimitFunc.
+func (mock *MongoDBMock) ListBundleContentsWithoutLimit(ctx context.Context, bundleID string) ([]*models.ContentItem, int, error) {
+	if mock.ListBundleContentsWithoutLimitFunc == nil {
+		panic("MongoDBMock.ListBundleContentsWithoutLimitFunc: method is nil but MongoDB.ListBundleContentsWithoutLimit was just called")
+	}
+	callInfo := struct {
+		Ctx      context.Context
+		BundleID string
+	}{
+		Ctx:      ctx,
+		BundleID: bundleID,
+	}
+	mock.lockListBundleContentsWithoutLimit.Lock()
+	mock.calls.ListBundleContentsWithoutLimit = append(mock.calls.ListBundleContentsWithoutLimit, callInfo)
+	mock.lockListBundleContentsWithoutLimit.Unlock()
+	return mock.ListBundleContentsWithoutLimitFunc(ctx, bundleID)
+}
+
+// ListBundleContentsWithoutLimitCalls gets all the calls that were made to ListBundleContentsWithoutLimit.
+// Check the length with:
+//
+//	len(mockedMongoDB.ListBundleContentsWithoutLimitCalls())
+func (mock *MongoDBMock) ListBundleContentsWithoutLimitCalls() []struct {
+	Ctx      context.Context
+	BundleID string
+} {
+	var calls []struct {
+		Ctx      context.Context
+		BundleID string
+	}
+	mock.lockListBundleContentsWithoutLimit.RLock()
+	calls = mock.calls.ListBundleContentsWithoutLimit
+	mock.lockListBundleContentsWithoutLimit.RUnlock()
 	return calls
 }
 


### PR DESCRIPTION
### What

[Ticket](https://jira.ons.gov.uk/browse/DIS-2948)
- Create `DELETE /bundles/{bundle-id}` endpoint

### How to review

Check changes make sense and acceptance criteria is met

1. Run the `dataset-catalogue` stack using `make up-with-seed`
2. Make a `DELETE` request to `/bundles/bundle-1` and check that the bundle and associated content item has been deleted. Also check that one event has been made for the content item and one has been made for the bundle
3. Make the same `DELETE` request to `/bundles/bundle-1` and this should return a 404 not found
4. Go into mongo and change one of the bundles to state `PUBLISHED`. Try to delete this bundle and you should receive a 409 conflict with the error description:
`"Change rejected due to a conflict with the current resource state. A common cause is attempting to change a bundle that is already locked pending publication or has already been published." and an error code of "Conflict"`

This should cover the acceptance criteria and these cases should also be listed in the component tests

### Who can review

Anyone
