### PR TITLE
Feature/populate updated at when creating bundle

### DIFF
--- a/mongo/bundle_store.go
+++ b/mongo/bundle_store.go
@@ -73,6 +73,7 @@ func buildGetBundleQuery(bundleID string) bson.M {
 func (m *Mongo) CreateBundle(ctx context.Context, bundle *models.Bundle) error {
 	now := time.Now()
 	bundle.CreatedAt = &now
+	bundle.UpdatedAt = &now
 	collectionName := m.ActualCollectionName(config.BundlesCollection)
 
 	_, err := m.Connection.Collection(collectionName).InsertOne(ctx, bundle)

--- a/mongo/bundle_store_test.go
+++ b/mongo/bundle_store_test.go
@@ -311,6 +311,8 @@ func TestCreateBundle_Success(t *testing.T) {
 				So(returnedBundle.Title, ShouldEqual, "New Bundle")
 				So(returnedBundle.ManagedBy, ShouldEqual, models.ManagedByWagtail)
 				So(returnedBundle.ETag, ShouldEqual, "some-etag")
+				So(returnedBundle.CreatedAt, ShouldNotBeNil)
+				So(returnedBundle.UpdatedAt, ShouldNotBeNil)
 			})
 		})
 	})

--- a/mongo/bundle_store_test.go
+++ b/mongo/bundle_store_test.go
@@ -6,14 +6,15 @@ import (
 	"time"
 
 	"github.com/ONSdigital/dis-bundle-api/apierrors"
+	"github.com/ONSdigital/dis-bundle-api/config"
 	"github.com/ONSdigital/dis-bundle-api/filters"
 	"github.com/ONSdigital/dis-bundle-api/models"
 	. "github.com/smartystreets/goconvey/convey"
 	"go.mongodb.org/mongo-driver/bson"
 )
 
-func setupBundleTestData(ctx context.Context, mongo *Mongo) ([]*models.Bundle, error) {
-	if err := mongo.Connection.DropDatabase(ctx); err != nil {
+func setupBundleTestData(ctx context.Context, mongodb *Mongo) ([]*models.Bundle, error) {
+	if err := mongodb.Connection.DropDatabase(ctx); err != nil {
 		return nil, err
 	}
 
@@ -62,8 +63,8 @@ func setupBundleTestData(ctx context.Context, mongo *Mongo) ([]*models.Bundle, e
 		},
 	}
 
-	for _, b := range bundles {
-		if err := mongo.CreateBundle(ctx, b); err != nil {
+	for _, bundle := range bundles {
+		if _, err := mongodb.Connection.Collection(mongodb.ActualCollectionName(config.BundlesCollection)).InsertOne(ctx, bundle); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
### What

Populate `updated_at` field when creating a bundle. This was missing from when POST /bundles was created and is required by the swagger spec.
Fixed bug with unit tests where certain time fields were being updated when creating a bundle which could cause unit tests to fail as they expected the bundles defined in the test

### How to review

Check changes are ok
`POST /bundles` returns the updated_at field
Used this body:
```
{ 
    "bundle_type": "SCHEDULED",
    "preview_teams": [ { "id": "team1" }, { "id": "team2" } ],
    "scheduled_at": "2025-09-05T07:00:00.000Z",
    "state": "DRAFT",
    "title": "Title 3",
    "managed_by": "WAGTAIL"
}
```

### Who can review

Anyone
