### PR TITLE
fix(getbundles): correct code returned for bad invalid filter + add component tests

### DIFF
--- a/api/bundles.go
+++ b/api/bundles.go
@@ -34,9 +34,9 @@ func (api *BundleAPI) getBundles(w http.ResponseWriter, r *http.Request, limit, 
 	filters, filtersErr := filters.CreateBundlefilters(r)
 	if filtersErr != nil {
 		log.Error(ctx, filtersErr.Error.Error(), errs.ErrInvalidQueryParameter)
-		code := models.CodeInternalServerError
+		code := models.CodeBadRequest
 		invalidRequestError := &models.Error{Code: &code, Description: errs.ErrorDescriptionMalformedRequest, Source: filtersErr.Source}
-		return nil, models.CreateInternalServerErrorResult(invalidRequestError)
+		return nil, models.CreateBadRequestErrorResult(invalidRequestError)
 	}
 
 	bundles, totalCount, err := api.stateMachineBundleAPI.ListBundles(ctx, offset, limit, filters)

--- a/api/bundles_test.go
+++ b/api/bundles_test.go
@@ -346,9 +346,9 @@ func TestGetBundles_Failure(t *testing.T) {
 			bundleAPI := GetBundleAPIWithMocks(store.Datastore{Backend: mockedDatastore}, mockAPIClient, false)
 
 			bundleAPI.Router.ServeHTTP(w, r)
-			Convey("Then the status code should be 500", func() {
-				So(w.Code, ShouldEqual, http.StatusInternalServerError)
-				expectedErrorCode := models.CodeInternalServerError
+			Convey("Then the status code should be 400", func() {
+				So(w.Code, ShouldEqual, http.StatusBadRequest)
+				expectedErrorCode := models.CodeBadRequest
 				expectedErrorSource := models.Source{
 					Parameter: "publish_date",
 				}

--- a/features/bundles_get_multiple.feature
+++ b/features/bundles_get_multiple.feature
@@ -228,3 +228,80 @@ Feature: List bundles - GET /Bundles
         When I GET "/bundles"
         Then the HTTP status code should be "401"
         And the response body should be empty
+
+    Scenario: GET /bundles with valid publish_date filter 
+        Given I am an admin user
+        When I GET "/bundles?publish_date=2025-05-05T08:00:00Z"
+        Then the HTTP status code should be "200"
+        And the response header "Content-Type" should be "application/json"
+        Then I should receive the following JSON response:
+            """
+            {
+                "items": [
+                    {
+                        "id": "bundle-1",
+                        "bundle_type": "SCHEDULED",
+                        "created_by": {
+                            "email": "publisher@ons.gov.uk"
+                        },
+                        "created_at": "2025-04-03T11:25:00Z",
+                        "last_updated_by": {
+                            "email": "publisher@ons.gov.uk"
+                        },
+                        "preview_teams": [
+                            {
+                                "id": "890m231k-98df-11ec-b909-0242ac120002"
+                            }
+                        ],
+                        "scheduled_at": "2025-05-05T08:00:00Z",
+                        "state": "DRAFT",
+                        "title": "bundle-1",
+                        "updated_at": "2025-04-03T11:25:00Z",
+                        "managed_by": "WAGTAIL"
+                    }
+                ],
+                "count": 1,
+                "limit": 20,
+                "offset": 0,
+                "total_count": 1
+            }
+            """
+        And the response header "ETag" should not be empty
+        And the response header "Cache-Control" should be "no-store"
+
+    Scenario: GET /bundles with valid publish_date filter that has no matches
+        Given I am an admin user
+        When I GET "/bundles?publish_date=2030-05-05T08:00:00Z"
+        Then the HTTP status code should be "404"
+        And the response header "Content-Type" should be "application/json"
+        And I should receive the following JSON response:
+            """
+            {
+                "errors": [
+                    {
+                        "code": "not_found",
+                        "description": "The requested resource does not exist"
+                    }
+                ]
+            }
+            """
+
+    Scenario: GET /bundles with invalid publish_date filter
+        Given I am an admin user
+        When I GET "/bundles?publish_date=thisisnotavaliddatetime"
+        Then the HTTP status code should be "400"
+        And the response header "Content-Type" should be "application/json"
+        And I should receive the following JSON response:
+            """
+                {
+                    "errors": [
+                        {
+                            "code": "bad_request",
+                            "description": "Unable to process request due to a malformed or invalid request body or query parameter",
+                            "source": {
+                                "parameter": "publish_date"
+                            }
+                        }
+                    ]
+                }
+            """

--- a/models/responses.go
+++ b/models/responses.go
@@ -15,6 +15,11 @@ func CreateErrorResult[TError Error](err *TError, httpStatusCode int) *ErrorResu
 	}
 }
 
+// Create an error response with a 400 status code
+func CreateBadRequestErrorResult[TError Error](err *TError) *ErrorResult[TError] {
+	return CreateErrorResult(err, http.StatusBadRequest)
+}
+
 // Create an error response with a 500 status code
 func CreateInternalServerErrorResult[TError Error](err *TError) *ErrorResult[TError] {
 	return CreateErrorResult(err, http.StatusInternalServerError)


### PR DESCRIPTION
### What

- Fix the error code + HTTP status code returned for an invalid `publish_date` filter (internal error -> bad request)

- Add component tests for the filtering

### How to review

1. Send a GET bundles request with an invalid publish date filter (e.g. `http://www.thebundlesapi.com/bundles?publish_date=this-is-not-valid`
2. Assert that the response:
  - Has a 400 status code
  - Has a `code` value in the JSON response of `bad_request` 

### Who can review

Anyone but me