### PR TITLE
Feature/amend put bundle state transitions

### DIFF
--- a/apierrors/errors.go
+++ b/apierrors/errors.go
@@ -88,7 +88,7 @@ var (
 	ErrExpectedStateOfCreated  = errors.New("expected bundle state to be 'CREATED'")
 	ErrExpectedStateOfApproved = errors.New("expected bundle state to be 'APPROVED'")
 	ErrInvalidTransition       = errors.New("state not allowed to transition")
-	ErrVersionStateMismatched  = errors.New("version state does not match content item state")
+	ErrVersionStateNotApproved = errors.New("version state expected to be APPROVED when transitioning bundle to PUBLISHED")
 )
 
 // 404 Not Found

--- a/application/application.go
+++ b/application/application.go
@@ -233,14 +233,13 @@ func (s *StateMachineBundleAPI) updateVersionStateForContentItem(ctx context.Con
 	versionID := strconv.Itoa(contentItem.Metadata.VersionID)
 
 	version, err := s.DatasetAPIClient.GetVersion(ctx, headers, contentItem.Metadata.DatasetID, contentItem.Metadata.EditionID, versionID)
-
 	if err != nil {
 		return err
 	}
 
-	if !strings.EqualFold(version.State, contentItem.State.String()) {
-		log.Warn(ctx, "Version state does not match ContentItem state", log.Data{"content-item-id": contentItem.ID, "version-state": version.State, "content-item-state": contentItem.State.String()})
-		return errs.ErrVersionStateMismatched
+	if targetState.String() == models.StatePublished.String() && !strings.EqualFold(version.State, models.StateApproved.String()) {
+		log.Warn(ctx, "Version state is not approved", log.Data{"content-item-id": contentItem.ID, "version-state": version.State, "target-state": targetState.String()})
+		return errs.ErrVersionStateNotApproved
 	}
 
 	if err := s.DatasetAPIClient.PutVersionState(ctx, headers, contentItem.Metadata.DatasetID, contentItem.Metadata.EditionID, versionID, strings.ToLower(targetState.String())); err != nil {

--- a/application/application_test.go
+++ b/application/application_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ONSdigital/dis-bundle-api/models"
 	"github.com/ONSdigital/dis-bundle-api/store"
 	storetest "github.com/ONSdigital/dis-bundle-api/store/datastoretest"
+	"github.com/ONSdigital/dis-bundle-api/utils"
 	datasetAPIModels "github.com/ONSdigital/dp-dataset-api/models"
 	"github.com/ONSdigital/dp-dataset-api/sdk"
 	datasetAPIMocks "github.com/ONSdigital/dp-dataset-api/sdk/mocks"
@@ -236,7 +237,7 @@ func TestCreateContentItem(t *testing.T) {
 				VersionID: 1,
 				Title:     "Test Dataset 1",
 			},
-			State: ptrContentItemState(models.StateApproved),
+			State: utils.PtrContentItemState(models.StateApproved),
 			Links: models.Links{
 				Edit:    "/edit/datasets/dataset1/editions/2025/versions/1",
 				Preview: "/preview/datasets/dataset1/editions/2025/versions/1",
@@ -960,10 +961,6 @@ func TestValidateScheduledAt_Failure_ScheduledAtInThePast(t *testing.T) {
 			})
 		})
 	})
-}
-
-func ptrContentItemState(s models.State) *models.State {
-	return &s
 }
 
 func TestGetBundleContents(t *testing.T) {

--- a/application/state_machine_test.go
+++ b/application/state_machine_test.go
@@ -395,30 +395,15 @@ func TestTransitionBundle_Success(t *testing.T) {
 			State:     strings.ToLower(mockBundle.State.String()),
 		},
 		{
-			ID:        "invalid-state-version",
+			ID:        "valid-version-2",
 			Version:   1,
 			DatasetID: "dataset-id-2",
 			Edition:   "edition-id-2",
-			State:     "some-invalid-state",
-		},
-		{
-			ID:        "valid-version-but-invalid-contentitem-2",
-			Version:   10000,
-			DatasetID: "dataset-id-100",
-			Edition:   "edition-id-20000",
-			State:     strings.ToLower(mockBundle.State.String()),
-		},
-		{
-			ID:        "valid-version-3",
-			Version:   1,
-			DatasetID: "dataset-id-3",
-			Edition:   "edition-id-3",
 			State:     strings.ToLower(mockBundle.State.String()),
 		},
 	}
 
 	validContentItemState := models.State(mockBundle.State.String())
-	invalidContentItemState := models.State(models.BundleStateDraft)
 
 	mockContentItems := []*models.ContentItem{
 		{
@@ -432,43 +417,13 @@ func TestTransitionBundle_Success(t *testing.T) {
 			},
 		},
 		{
-			ID:       "invalid-state-content-item",
-			BundleID: mockBundleID,
-			State:    &invalidContentItemState,
-			Metadata: models.Metadata{
-				DatasetID: mockVersions[2].DatasetID,
-				EditionID: mockVersions[2].Edition,
-				VersionID: mockVersions[2].Version,
-			},
-		},
-		{
-			ID:       "invalid-version-state-content-item",
+			ID:       "another-valid-content-item",
 			BundleID: mockBundleID,
 			State:    &validContentItemState,
 			Metadata: models.Metadata{
 				DatasetID: mockVersions[1].DatasetID,
 				EditionID: mockVersions[1].Edition,
 				VersionID: mockVersions[1].Version,
-			},
-		},
-		{
-			ID:       "missing-version-content-item",
-			BundleID: mockBundleID,
-			State:    &validContentItemState,
-			Metadata: models.Metadata{
-				DatasetID: "does-not-exist-dataset",
-				EditionID: "not-found",
-				VersionID: 1,
-			},
-		},
-		{
-			ID:       "another-valid-content-item",
-			BundleID: mockBundleID,
-			State:    &validContentItemState,
-			Metadata: models.Metadata{
-				DatasetID: mockVersions[3].DatasetID,
-				EditionID: mockVersions[3].Edition,
-				VersionID: mockVersions[3].Version,
 			},
 		},
 	}
@@ -578,23 +533,15 @@ func TestTransitionBundle_Success(t *testing.T) {
 			})
 		})
 
-		contentItemsThatShouldBeUpdated := []*models.ContentItem{mockContentItems[0], mockContentItems[4]}
-		contentItemsThatShouldntBeUpdated := []*models.ContentItem{mockContentItems[1], mockContentItems[2], mockContentItems[3]}
+		contentItemsThatShouldBeUpdated := []*models.ContentItem{mockContentItems[0], mockContentItems[1]}
 
 		Convey("And the content items should be updated if the state matched", func() {
 			for _, contentItem := range contentItemsThatShouldBeUpdated {
 				So(contentItem.State.String(), ShouldEqual, targetState.String())
 			}
-
-			Convey("And not be updated if the state did not match", func() {
-				for _, contentItem := range contentItemsThatShouldntBeUpdated {
-					So(contentItem.State.String(), ShouldNotEqual, targetState.String())
-				}
-			})
 		})
 
-		versionsThatShouldBeUpdated := []int{0, 3}
-		versionsThatShouldNotBeUpdated := []int{1, 2}
+		versionsThatShouldBeUpdated := []int{0, 1}
 
 		Convey("And the versions should be updated if the state matched", func() {
 			for index := range versionsThatShouldBeUpdated {
@@ -602,14 +549,6 @@ func TestTransitionBundle_Success(t *testing.T) {
 
 				So(strings.ToLower(mockVersion.State), ShouldEqual, strings.ToLower(targetState.String()))
 			}
-
-			Convey("And not be updated if the state did not match", func() {
-				for index := range versionsThatShouldNotBeUpdated {
-					mockVersion := mockVersions[versionsThatShouldNotBeUpdated[index]]
-
-					So(strings.ToLower(mockVersion.State), ShouldNotEqual, strings.ToLower(targetState.String()))
-				}
-			})
 		})
 
 		Convey("And events should be created", func() {
@@ -671,30 +610,15 @@ func TestTransitionBundle_Failure(t *testing.T) {
 			State:     strings.ToLower(mockBundle.State.String()),
 		},
 		{
-			ID:        "invalid-state-version",
+			ID:        "valid-version-2",
 			Version:   1,
 			DatasetID: "dataset-id-2",
 			Edition:   "edition-id-2",
-			State:     "some-invalid-state",
-		},
-		{
-			ID:        "valid-version-but-invalid-contentitem-2",
-			Version:   10000,
-			DatasetID: "dataset-id-100",
-			Edition:   "edition-id-20000",
-			State:     strings.ToLower(mockBundle.State.String()),
-		},
-		{
-			ID:        "valid-version-3",
-			Version:   1,
-			DatasetID: "dataset-id-3",
-			Edition:   "edition-id-3",
 			State:     strings.ToLower(mockBundle.State.String()),
 		},
 	}
 
 	validContentItemState := models.State(mockBundle.State.String())
-	invalidContentItemState := models.State(models.BundleStateDraft)
 
 	mockContentItems := []*models.ContentItem{
 		{
@@ -708,43 +632,13 @@ func TestTransitionBundle_Failure(t *testing.T) {
 			},
 		},
 		{
-			ID:       "invalid-state-content-item",
-			BundleID: mockBundleID,
-			State:    &invalidContentItemState,
-			Metadata: models.Metadata{
-				DatasetID: mockVersions[2].DatasetID,
-				EditionID: mockVersions[2].Edition,
-				VersionID: mockVersions[2].Version,
-			},
-		},
-		{
-			ID:       "invalid-version-state-content-item",
+			ID:       "another-valid-content-item",
 			BundleID: mockBundleID,
 			State:    &validContentItemState,
 			Metadata: models.Metadata{
 				DatasetID: mockVersions[1].DatasetID,
 				EditionID: mockVersions[1].Edition,
 				VersionID: mockVersions[1].Version,
-			},
-		},
-		{
-			ID:       "missing-version-content-item",
-			BundleID: mockBundleID,
-			State:    &validContentItemState,
-			Metadata: models.Metadata{
-				DatasetID: "does-not-exist-dataset",
-				EditionID: "not-found",
-				VersionID: 1,
-			},
-		},
-		{
-			ID:       "another-valid-content-item",
-			BundleID: mockBundleID,
-			State:    &validContentItemState,
-			Metadata: models.Metadata{
-				DatasetID: mockVersions[3].DatasetID,
-				EditionID: mockVersions[3].Edition,
-				VersionID: mockVersions[3].Version,
 			},
 		},
 	}
@@ -934,8 +828,17 @@ func TestTransitionBundle_Failure(t *testing.T) {
 
 		createEventError := errors.New("create event error")
 
+		// previous test would have published all versions so we need to reset them
+		for index := range mockVersions {
+			mockVersions[index].State = strings.ToLower(fromState.String())
+		}
+
 		mockedDatastore.CreateBundleEventFunc = func(ctx context.Context, event *models.Event) error {
-			return createEventError
+			// To avoid throwing the error when content items are updated
+			if event.Bundle != nil {
+				return createEventError
+			}
+			return nil
 		}
 
 		stateMachine := NewStateMachine(ctx, states, transitions, store.Datastore{Backend: mockedDatastore})

--- a/features/bundles_put_state.feature
+++ b/features/bundles_put_state.feature
@@ -163,8 +163,7 @@ Feature: Update Bundles functionality - PUT /bundles/{id}/state
                     "links": {
                         "edit": "edit/link",
                         "preview": "preview/link"
-                    },
-                    "state": "DRAFT"
+                    }
                 },
                 {
                     "id": "content-item-2",
@@ -179,8 +178,7 @@ Feature: Update Bundles functionality - PUT /bundles/{id}/state
                     "links": {
                         "edit": "edit/link",
                         "preview": "preview/link"
-                    },
-                    "state": "IN_REVIEW"
+                    }
                 },
                 {
                     "id": "content-item-3",
@@ -211,8 +209,7 @@ Feature: Update Bundles functionality - PUT /bundles/{id}/state
                     "links": {
                         "edit": "edit/link",
                         "preview": "preview/link"
-                    },
-                    "state": "IN_REVIEW"
+                    }
                 },
                 {
                     "id": "content-item-13",
@@ -227,8 +224,7 @@ Feature: Update Bundles functionality - PUT /bundles/{id}/state
                     "links": {
                         "edit": "edit/link",
                         "preview": "preview/link"
-                    },
-                    "state": "IN_REVIEW"
+                    }
                 },
                 {
                     "id": "content-item-14",
@@ -243,8 +239,7 @@ Feature: Update Bundles functionality - PUT /bundles/{id}/state
                     "links": {
                         "edit": "edit/link",
                         "preview": "preview/link"
-                    },
-                    "state": "DRAFT"
+                    }
                 },
                 {
                     "id": "content-item-15",
@@ -259,8 +254,7 @@ Feature: Update Bundles functionality - PUT /bundles/{id}/state
                     "links": {
                         "edit": "edit/link",
                         "preview": "preview/link"
-                    },
-                    "state": "IN_REVIEW"
+                    }
                 },
                 {
                     "id": "content-item-16",
@@ -275,8 +269,7 @@ Feature: Update Bundles functionality - PUT /bundles/{id}/state
                     "links": {
                         "edit": "edit/link",
                         "preview": "preview/link"
-                    },
-                    "state": "IN_REVIEW"
+                    }
                 },
                 {
                     "id": "content-item-17",
@@ -291,8 +284,7 @@ Feature: Update Bundles functionality - PUT /bundles/{id}/state
                     "links": {
                         "edit": "edit/link",
                         "preview": "preview/link"
-                    },
-                    "state": "IN_REVIEW"
+                    }
                 }
             ]
             """
@@ -311,35 +303,35 @@ Feature: Update Bundles functionality - PUT /bundles/{id}/state
                     "version": 1,
                     "dataset_id": "dataset5",
                     "edition": "edition5",
-                    "state": "in_review" 
+                    "state": "associated" 
                 },
                 {
                     "id": "version-3",
                     "version": 1,
                     "dataset_id": "dataset6",
                     "edition": "edition6",
-                    "state": "in_review" 
+                    "state": "associated" 
                 },
                  {
                     "id": "version-4",
                     "version": 1,
                     "dataset_id": "dataset7",
                     "edition": "edition7",
-                    "state": "draft" 
+                    "state": "associated" 
                 },
                  {
                     "id": "version-5",
                     "version": 1,
                     "dataset_id": "dataset8",
                     "edition": "edition8",
-                    "state": "draft" 
+                    "state": "associated" 
                 },
                 {
                     "id": "version-6",
                     "version": 10,
                     "dataset_id": "dataset9",
                     "edition": "edition9",
-                    "state": "in_review" 
+                    "state": "associated" 
                 }
             ]
             """
@@ -516,9 +508,9 @@ Feature: Update Bundles functionality - PUT /bundles/{id}/state
                     "state": "APPROVED"
                 }
             """
-        Then the HTTP status code should be "200"
-        And bundle "bundle-10" should have state "APPROVED"
-        And bundle "bundle-10" should not have this etag "etag-bundle-10"
+        Then the HTTP status code should be "500"
+        And bundle "bundle-10" should have state "IN_REVIEW"
+        And bundle "bundle-10" should have this etag "etag-bundle-10"
 
 
     Scenario: PUT /bundles/{id}/state with valid arguments for 'IN_REVIEW' -> 'APPROVED'
@@ -548,14 +540,6 @@ Feature: Update Bundles functionality - PUT /bundles/{id}/state
                         "state": "APPROVED"
                     },
                     {
-                        "id": "content-item-14",
-                        "state": "DRAFT"
-                    },
-                    {
-                        "id": "content-item-15",
-                        "state": "IN_REVIEW"
-                    },
-                    {
                         "id": "content-item-16",
                         "state": "APPROVED"
                     }
@@ -574,11 +558,11 @@ Feature: Update Bundles functionality - PUT /bundles/{id}/state
                 },
                     {
                     "id": "version-4",
-                    "state": "draft" 
+                    "state": "approved" 
                 },
                     {
                     "id": "version-5",
-                    "state": "draft" 
+                    "state": "approved" 
                 },
                 {
                     "id": "version-6",

--- a/mongo/bundle_contents_store_test.go
+++ b/mongo/bundle_contents_store_test.go
@@ -404,7 +404,7 @@ func TestUpdateContentItemState_Success(t *testing.T) {
 		err = setupBundleContentsTestData(ctx, mongodb)
 		So(err, ShouldBeNil)
 
-		Convey("When GetBundleContentsForBundle is called with a valid bundle ID", func() {
+		Convey("When UpdateContentItemState is called with a valid ContentItemID", func() {
 			contentItemID := contentsTestData[0].ID
 			state := models.StatePublished
 

--- a/utils/unit_testing_utils.go
+++ b/utils/unit_testing_utils.go
@@ -1,0 +1,8 @@
+package utils
+
+import "github.com/ONSdigital/dis-bundle-api/models"
+
+// PtrContentItemState returns a pointer for content item state
+func PtrContentItemState(s models.State) *models.State {
+	return &s
+}


### PR DESCRIPTION
### What

[Ticket](https://jira.ons.gov.uk/browse/DIS-3301)

-  Sandbox had issues with nil pointer errors since content items are created without a state and can only be `APPROVED` or `PUBLISHED`.  Changes made so that content item states are only updated when transitioning to `APPROVED` or `PUBLISHED`. 
- This endpoint was initially made assuming that all valid bundle states (`DRAFT`, `IN_REVIEW`, `APPROVED`, `PUBLISHED`) were used within content items and dataset versions but this is not the case so tests needed to amended so that `DRAFT` and `IN_REVIEW` can't be set for content items or dataset versions.

### How to review

Check changes make sense
Should be able to update a bundle through all possible states (`DRAFT`, `IN_REVIEW`, `APPROVED`, `PUBLISHED`) by using `PUT /bundles/{bundle-id}/state`

endpoints in order to test this:
```
POST /bundles
POST /datasets
POST /datasets/{dataset-id}/editions/{edition-id}/versions
PUT /bundles/{bundle-id}/state 
(repeat the PUT to transition through all states)
```

### Who can review

Anyone
