### PR TITLE
Feature/remove manually typed error descriptions

### DIFF
--- a/api/bundle_events.go
+++ b/api/bundle_events.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"time"
 
-	errs "github.com/ONSdigital/dis-bundle-api/apierrors"
+	"github.com/ONSdigital/dis-bundle-api/apierrors"
 	"github.com/ONSdigital/dis-bundle-api/models"
 	"github.com/ONSdigital/dis-bundle-api/utils"
 	"github.com/ONSdigital/log.go/v2/log"
@@ -28,7 +28,7 @@ func (api *BundleAPI) getBundleEvents(w http.ResponseWriter, r *http.Request, li
 			code := models.CodeInvalidParameters
 			errInfo := &models.Error{
 				Code:        &code,
-				Description: errs.ErrorDescriptionMalformedRequest,
+				Description: apierrors.ErrorDescriptionMalformedRequest,
 				Source:      &models.Source{Parameter: param},
 			}
 			validationErrors = append(validationErrors, errInfo)
@@ -47,7 +47,7 @@ func (api *BundleAPI) getBundleEvents(w http.ResponseWriter, r *http.Request, li
 			code := models.CodeInvalidParameters
 			errInfo := &models.Error{
 				Code:        &code,
-				Description: errs.ErrorDescriptionMalformedRequest,
+				Description: apierrors.ErrorDescriptionMalformedRequest,
 				Source:      &models.Source{Parameter: "after"},
 			}
 			validationErrors = append(validationErrors, errInfo)
@@ -62,7 +62,7 @@ func (api *BundleAPI) getBundleEvents(w http.ResponseWriter, r *http.Request, li
 			code := models.CodeInvalidParameters
 			errInfo := &models.Error{
 				Code:        &code,
-				Description: errs.ErrorDescriptionMalformedRequest,
+				Description: apierrors.ErrorDescriptionMalformedRequest,
 				Source:      &models.Source{Parameter: "before"},
 			}
 			validationErrors = append(validationErrors, errInfo)
@@ -80,14 +80,14 @@ func (api *BundleAPI) getBundleEvents(w http.ResponseWriter, r *http.Request, li
 	if err != nil {
 		code := models.CodeInternalError
 		log.Error(ctx, "failed to get bundle events", err)
-		errInfo := &models.Error{Code: &code, Description: "Failed to process the request due to an internal error"}
+		errInfo := &models.Error{Code: &code, Description: apierrors.ErrorDescriptionInternalError}
 		utils.HandleBundleAPIErr(w, r, http.StatusInternalServerError, errInfo)
 		return nil, 0, nil
 	}
 
 	if totalCount == 0 {
 		code := models.CodeNotFound
-		errInfo := &models.Error{Code: &code, Description: "The requested resource does not exist."}
+		errInfo := &models.Error{Code: &code, Description: apierrors.ErrorDescriptionNotFound}
 		utils.HandleBundleAPIErr(w, r, http.StatusNotFound, errInfo)
 		return nil, 0, errInfo
 	}

--- a/api/bundle_update.go
+++ b/api/bundle_update.go
@@ -34,7 +34,7 @@ func (api *BundleAPI) putBundle(w http.ResponseWriter, r *http.Request) {
 		code := models.CodeConflict
 		errInfo := &models.Error{
 			Code:        &code,
-			Description: "Change rejected due to a conflict with the current resource state. A common cause is attempted to change a bundle that is already locked pending publication or has already been published.",
+			Description: apierrors.ErrorDescriptionConflict,
 		}
 		utils.HandleBundleAPIErr(w, r, http.StatusConflict, errInfo)
 		return
@@ -60,7 +60,7 @@ func (api *BundleAPI) putBundle(w http.ResponseWriter, r *http.Request) {
 		code := models.CodeConflict
 		errInfo := &models.Error{
 			Code:        &code,
-			Description: "Change rejected due to a conflict with the current resource state. A common cause is attempted to change a bundle that is already locked pending publication or has already been published.",
+			Description: apierrors.ErrorDescriptionConflict,
 		}
 		utils.HandleBundleAPIErr(w, r, http.StatusConflict, errInfo)
 		return
@@ -109,7 +109,7 @@ func (api *BundleAPI) putBundle(w http.ResponseWriter, r *http.Request) {
 			code := models.CodeNotFound
 			errInfo := &models.Error{
 				Code:        &code,
-				Description: "The requested resource does not exist.",
+				Description: apierrors.ErrorDescriptionNotFound,
 				Source:      &models.Source{Field: "/dataset_id"},
 			}
 			utils.HandleBundleAPIErr(w, r, http.StatusNotFound, errInfo)

--- a/api/bundle_update_test.go
+++ b/api/bundle_update_test.go
@@ -159,7 +159,7 @@ func TestPutBundle_MissingIfMatchHeader_Failure(t *testing.T) {
 					Errors: []*models.Error{
 						{
 							Code:        &codeConflict,
-							Description: "Change rejected due to a conflict with the current resource state. A common cause is attempted to change a bundle that is already locked pending publication or has already been published.",
+							Description: apierrors.ErrorDescriptionConflict,
 						},
 					},
 				}
@@ -221,7 +221,7 @@ func TestPutBundle_ETagMismatch_Failure(t *testing.T) {
 					Errors: []*models.Error{
 						{
 							Code:        &codeConflict,
-							Description: "Change rejected due to a conflict with the current resource state. A common cause is attempted to change a bundle that is already locked pending publication or has already been published.",
+							Description: apierrors.ErrorDescriptionConflict,
 						},
 					},
 				}

--- a/api/contents.go
+++ b/api/contents.go
@@ -49,7 +49,7 @@ func (api *BundleAPI) postBundleContents(w http.ResponseWriter, r *http.Request)
 		code := models.CodeInternalError
 		errInfo := &models.Error{
 			Code:        &code,
-			Description: "Failed to check if bundle exists",
+			Description: apierrors.ErrorDescriptionInternalError,
 		}
 		utils.HandleBundleAPIErr(w, r, http.StatusInternalServerError, errInfo)
 		return
@@ -59,7 +59,7 @@ func (api *BundleAPI) postBundleContents(w http.ResponseWriter, r *http.Request)
 		code := models.CodeNotFound
 		errInfo := &models.Error{
 			Code:        &code,
-			Description: "Bundle not found",
+			Description: apierrors.ErrorDescriptionNotFound,
 		}
 		utils.HandleBundleAPIErr(w, r, http.StatusNotFound, errInfo)
 		return
@@ -113,7 +113,7 @@ func (api *BundleAPI) postBundleContents(w http.ResponseWriter, r *http.Request)
 			code := models.CodeInternalError
 			errInfo := &models.Error{
 				Code:        &code,
-				Description: "Failed to get version from dataset API",
+				Description: apierrors.ErrorDescriptionInternalError,
 			}
 			utils.HandleBundleAPIErr(w, r, http.StatusInternalServerError, errInfo)
 			return
@@ -126,7 +126,7 @@ func (api *BundleAPI) postBundleContents(w http.ResponseWriter, r *http.Request)
 		code := models.CodeInternalError
 		errInfo := &models.Error{
 			Code:        &code,
-			Description: "Failed to check if content item exists",
+			Description: apierrors.ErrorDescriptionInternalError,
 		}
 		utils.HandleBundleAPIErr(w, r, http.StatusInternalServerError, errInfo)
 		return
@@ -137,7 +137,7 @@ func (api *BundleAPI) postBundleContents(w http.ResponseWriter, r *http.Request)
 		code := models.CodeConflict
 		errInfo := &models.Error{
 			Code:        &code,
-			Description: "Content item already exists for the given dataset, edition and version",
+			Description: apierrors.ErrorDescriptionConflict,
 		}
 		utils.HandleBundleAPIErr(w, r, http.StatusConflict, errInfo)
 		return
@@ -149,7 +149,7 @@ func (api *BundleAPI) postBundleContents(w http.ResponseWriter, r *http.Request)
 		code := models.CodeInternalError
 		errInfo := &models.Error{
 			Code:        &code,
-			Description: "Failed to create content item in the datastore",
+			Description: apierrors.ErrorDescriptionInternalError,
 		}
 		utils.HandleBundleAPIErr(w, r, http.StatusInternalServerError, errInfo)
 		return
@@ -161,7 +161,7 @@ func (api *BundleAPI) postBundleContents(w http.ResponseWriter, r *http.Request)
 		code := models.CodeInternalError
 		errInfo := &models.Error{
 			Code:        &code,
-			Description: "Failed to get user identity from JWT",
+			Description: apierrors.ErrorDescriptionInternalError,
 		}
 		utils.HandleBundleAPIErr(w, r, http.StatusInternalServerError, errInfo)
 		return
@@ -185,7 +185,7 @@ func (api *BundleAPI) postBundleContents(w http.ResponseWriter, r *http.Request)
 		code := models.CodeInternalError
 		errInfo := &models.Error{
 			Code:        &code,
-			Description: "Failed to validate event",
+			Description: apierrors.ErrorDescriptionInternalError,
 		}
 		utils.HandleBundleAPIErr(w, r, http.StatusInternalServerError, errInfo)
 		return
@@ -197,7 +197,7 @@ func (api *BundleAPI) postBundleContents(w http.ResponseWriter, r *http.Request)
 		code := models.CodeInternalError
 		errInfo := &models.Error{
 			Code:        &code,
-			Description: "Failed to create event",
+			Description: apierrors.ErrorDescriptionInternalError,
 		}
 		utils.HandleBundleAPIErr(w, r, http.StatusInternalServerError, errInfo)
 		return
@@ -209,7 +209,7 @@ func (api *BundleAPI) postBundleContents(w http.ResponseWriter, r *http.Request)
 		code := models.CodeInternalError
 		errInfo := &models.Error{
 			Code:        &code,
-			Description: "Failed to update bundle ETag",
+			Description: apierrors.ErrorDescriptionInternalError,
 		}
 		utils.HandleBundleAPIErr(w, r, http.StatusInternalServerError, errInfo)
 		return
@@ -221,7 +221,7 @@ func (api *BundleAPI) postBundleContents(w http.ResponseWriter, r *http.Request)
 		code := models.CodeInternalError
 		errInfo := &models.Error{
 			Code:        &code,
-			Description: "Failed to marshal content item to JSON",
+			Description: apierrors.ErrorDescriptionInternalError,
 		}
 		utils.HandleBundleAPIErr(w, r, http.StatusInternalServerError, errInfo)
 		return
@@ -270,7 +270,7 @@ func (api *BundleAPI) deleteContentItem(w http.ResponseWriter, r *http.Request) 
 		code := models.CodeConflict
 		errInfo := &models.Error{
 			Code:        &code,
-			Description: apierrors.ErrorDescriptionAlreadyPublished,
+			Description: apierrors.ErrorDescriptionConflict,
 		}
 		utils.HandleBundleAPIErr(w, r, http.StatusConflict, errInfo)
 		return
@@ -358,7 +358,7 @@ func (api *BundleAPI) getBundleContents(w http.ResponseWriter, r *http.Request, 
 		code := models.CodeInternalError
 		errInfo := &models.Error{
 			Code:        &code,
-			Description: "Failed to check if bundle exists",
+			Description: apierrors.ErrorDescriptionInternalError,
 		}
 		return []*models.ContentItem{}, 0, errInfo
 	}
@@ -367,7 +367,7 @@ func (api *BundleAPI) getBundleContents(w http.ResponseWriter, r *http.Request, 
 		code := models.CodeNotFound
 		errInfo := &models.Error{
 			Code:        &code,
-			Description: "Bundle not found",
+			Description: apierrors.ErrorDescriptionNotFound,
 		}
 		return []*models.ContentItem{}, 0, errInfo
 	}
@@ -396,7 +396,7 @@ func (api *BundleAPI) getBundleContents(w http.ResponseWriter, r *http.Request, 
 			code := models.CodeInternalError
 			errInfo := &models.Error{
 				Code:        &code,
-				Description: "Failed to get dataset from dataset API",
+				Description: apierrors.ErrorDescriptionInternalError,
 			}
 			return nil, 0, errInfo
 		}

--- a/api/contents_test.go
+++ b/api/contents_test.go
@@ -275,7 +275,7 @@ func TestPostBundleContents_NonExistentBundle_Failure(t *testing.T) {
 					Errors: []*models.Error{
 						{
 							Code:        &codeInternalError,
-							Description: "Failed to check if bundle exists",
+							Description: apierrors.ErrorDescriptionInternalError,
 						},
 					},
 				}
@@ -303,7 +303,7 @@ func TestPostBundleContents_NonExistentBundle_Failure(t *testing.T) {
 					Errors: []*models.Error{
 						{
 							Code:        &codeNotFound,
-							Description: "Bundle not found",
+							Description: apierrors.ErrorDescriptionNotFound,
 						},
 					},
 				}
@@ -484,7 +484,7 @@ func TestPostBundleContents_NonExistentDatasetEditionOrVersion_Failure(t *testin
 					Errors: []*models.Error{
 						{
 							Code:        &codeInternalError,
-							Description: "Failed to get version from dataset API",
+							Description: apierrors.ErrorDescriptionInternalError,
 						},
 					},
 				}
@@ -557,7 +557,7 @@ func TestPostBundleContents_ExistingDatasetEditionAndVersion_Failure(t *testing.
 					Errors: []*models.Error{
 						{
 							Code:        &codeConflict,
-							Description: "Content item already exists for the given dataset, edition and version",
+							Description: apierrors.ErrorDescriptionConflict,
 						},
 					},
 				}
@@ -590,7 +590,7 @@ func TestPostBundleContents_ExistingDatasetEditionAndVersion_Failure(t *testing.
 					Errors: []*models.Error{
 						{
 							Code:        &codeInternalError,
-							Description: "Failed to check if content item exists",
+							Description: apierrors.ErrorDescriptionInternalError,
 						},
 					},
 				}
@@ -663,7 +663,7 @@ func TestPostBundleContents_CreateContentItem_Failure(t *testing.T) {
 					Errors: []*models.Error{
 						{
 							Code:        &codeInternalError,
-							Description: "Failed to create content item in the datastore",
+							Description: apierrors.ErrorDescriptionInternalError,
 						},
 					},
 				}
@@ -731,7 +731,7 @@ func TestPostBundleContents_ParseJWT_Failure(t *testing.T) {
 				Errors: []*models.Error{
 					{
 						Code:        &codeInternalError,
-						Description: "Failed to get user identity from JWT",
+						Description: apierrors.ErrorDescriptionInternalError,
 					},
 				},
 			}
@@ -805,7 +805,7 @@ func TestPostBundleContents_BundleEventCreation_Failure(t *testing.T) {
 				Errors: []*models.Error{
 					{
 						Code:        &codeInternalError,
-						Description: "Failed to create event",
+						Description: apierrors.ErrorDescriptionInternalError,
 					},
 				},
 			}
@@ -882,7 +882,7 @@ func TestPostBundleContents_UpdateBundleETag_Failure(t *testing.T) {
 				Errors: []*models.Error{
 					{
 						Code:        &codeInternalError,
-						Description: "Failed to update bundle ETag",
+						Description: apierrors.ErrorDescriptionInternalError,
 					},
 				},
 			}
@@ -1051,7 +1051,7 @@ func TestDeleteContentItem_ContentItemIsPublished_Failure(t *testing.T) {
 					Errors: []*models.Error{
 						{
 							Code:        &codeConflict,
-							Description: apierrors.ErrorDescriptionAlreadyPublished,
+							Description: apierrors.ErrorDescriptionConflict,
 						},
 					},
 				}
@@ -1560,7 +1560,7 @@ func TestGetBundleContents_Failure(t *testing.T) {
 					Errors: []*models.Error{
 						{
 							Code:        &codeNotFound,
-							Description: "Bundle not found",
+							Description: apierrors.ErrorDescriptionNotFound,
 						},
 					},
 				}
@@ -1599,7 +1599,7 @@ func TestGetBundleContents_Failure(t *testing.T) {
 					Errors: []*models.Error{
 						{
 							Code:        &codeInternalError,
-							Description: "Failed to get dataset from dataset API",
+							Description: apierrors.ErrorDescriptionInternalError,
 						},
 					},
 				}
@@ -1671,7 +1671,7 @@ func TestGetBundleContents_Failure(t *testing.T) {
 					Errors: []*models.Error{
 						{
 							Code:        &codeNotFound,
-							Description: "The requested resource does not exist",
+							Description: apierrors.ErrorDescriptionNotFound,
 							Source: &models.Source{
 								Field: "/metadata/dataset_id",
 							},

--- a/apierrors/errors.go
+++ b/apierrors/errors.go
@@ -15,28 +15,28 @@ func (e ErrInvalidPatch) Error() string {
 
 // Response error descriptions
 const (
-	ErrorDescriptionMalformedRequest  = "Unable to process request due to a malformed or invalid request body or query parameter"
-	ErrorDescriptionMissingParameters = "Unable to process request due to missing required parameters in the request body or query parameters"
-	ErrorDescriptionNotFound          = "The requested resource does not exist"
-	ErrorDescriptionInternalError     = "Failed to process the request due to an internal error"
-	ErrorDescriptionAlreadyPublished  = "Change rejected due to a conflict with the current resource state. A common cause is attempting to change a bundle that is already locked pending publication or has already been published."
+	ErrorDescriptionMalformedRequest  = "Unable to process request due to a malformed or invalid request body or query parameter."
+	ErrorDescriptionMissingParameters = "Unable to process request due to missing required parameters in the request body or query parameters."
+	ErrorDescriptionNotFound          = "The requested resource does not exist."
+	ErrorDescriptionInternalError     = "Failed to process the request due to an internal error."
+	ErrorDescriptionConflict          = "Change rejected due to a conflict with the current resource state. A common cause is attempting to change a bundle that is already locked pending publication or has already been published."
 
 	// Invalid etag
-	ErrorDescriptionMissingIfMatchHeader = "Unable to process request due to missing If-Match header"
-	ErrorDescriptionInvalidIfMatchHeader = "Unable to process request invalid If-Match header"
+	ErrorDescriptionMissingIfMatchHeader = "Unable to process request due to missing If-Match header."
+	ErrorDescriptionInvalidIfMatchHeader = "Unable to process request invalid If-Match header."
 
 	// Invalid state
-	ErrorDescriptionInvalidStateTransition = "Unable to process request due to invalid state transition"
+	ErrorDescriptionInvalidStateTransition = "Unable to process request due to invalid state transition."
 
 	// Auth
 	ErrorDescriptionAccessDenied = "Access denied."
 
-	ErrorDescriptionInvalidTimeFormat           = "Invalid time format in request body"
-	ErrorDescriptionScheduledAtIsInPast         = "scheduled_at cannot be in the past"
-	ErrorDescriptionScheduledAtShouldNotBeSet   = "scheduled_at should not be set for manual bundles"
-	ErrorDescriptionScheduledAtIsRequired       = "scheduled_at is required for scheduled bundles"
-	ErrorDescriptionBundleTitleAlreadyExist     = "A bundle with the same title already exists"
-	ErrorDescriptionStateNotAllowedToTransition = "state not allowed to transition"
+	ErrorDescriptionInvalidTimeFormat           = "Invalid time format in request body."
+	ErrorDescriptionScheduledAtIsInPast         = "scheduled_at cannot be in the past."
+	ErrorDescriptionScheduledAtShouldNotBeSet   = "scheduled_at should not be set for manual bundles."
+	ErrorDescriptionScheduledAtIsRequired       = "scheduled_at is required for scheduled bundles."
+	ErrorDescriptionBundleTitleAlreadyExist     = "A bundle with the same title already exists."
+	ErrorDescriptionStateNotAllowedToTransition = "state not allowed to transition."
 )
 
 var (

--- a/application/application.go
+++ b/application/application.go
@@ -342,7 +342,7 @@ func (s *StateMachineBundleAPI) DeleteBundle(ctx context.Context, bundleID, emai
 		code := models.CodeConflict
 		e := &models.Error{
 			Code:        &code,
-			Description: errs.ErrorDescriptionAlreadyPublished,
+			Description: errs.ErrorDescriptionConflict,
 		}
 		return http.StatusConflict, e, err
 	}

--- a/application/application_test.go
+++ b/application/application_test.go
@@ -1257,7 +1257,7 @@ func TestDeleteBundle_Failure_Transition(t *testing.T) {
 				code := models.CodeConflict
 				expectedErr := &models.Error{
 					Code:        &code,
-					Description: apierrors.ErrorDescriptionAlreadyPublished,
+					Description: apierrors.ErrorDescriptionConflict,
 				}
 				So(errObject, ShouldResemble, expectedErr)
 			})

--- a/features/bundle_update.feature
+++ b/features/bundle_update.feature
@@ -218,7 +218,7 @@ Scenario: PUT /bundles/{id} successfully updates a bundle
                 "errors": [
                     {
                         "code": "Conflict",
-                        "description": "Change rejected due to a conflict with the current resource state. A common cause is attempted to change a bundle that is already locked pending publication or has already been published."
+                        "description": "Change rejected due to a conflict with the current resource state. A common cause is attempting to change a bundle that is already locked pending publication or has already been published."
                     }
                 ]
             }
@@ -246,7 +246,7 @@ Scenario: PUT /bundles/{id} successfully updates a bundle
                 "errors": [
                     {
                         "code": "Conflict",
-                        "description": "Change rejected due to a conflict with the current resource state. A common cause is attempted to change a bundle that is already locked pending publication or has already been published."
+                        "description": "Change rejected due to a conflict with the current resource state. A common cause is attempting to change a bundle that is already locked pending publication or has already been published."
                     }
                 ]
             }
@@ -271,35 +271,35 @@ Scenario: PUT /bundles/{id} successfully updates a bundle
                 "errors": [
                     {
                         "code": "InvalidParameters",
-                        "description": "Unable to process request due to a malformed or invalid request body or query parameter",
+                        "description": "Unable to process request due to a malformed or invalid request body or query parameter.",
                         "source": {
                             "field": "/bundle_type"
                         }
                     },
                     {
                         "code": "MissingParameters",
-                        "description": "Unable to process request due to missing required parameters in the request body or query parameters",
+                        "description": "Unable to process request due to missing required parameters in the request body or query parameters.",
                         "source": {
                             "field": "/preview_teams"
                         }
                     },
                     {
                         "code": "InvalidParameters",
-                        "description": "Unable to process request due to a malformed or invalid request body or query parameter",
+                        "description": "Unable to process request due to a malformed or invalid request body or query parameter.",
                         "source": {
                             "field": "/state"
                         }
                     },
                     {
                         "code": "MissingParameters",
-                        "description": "Unable to process request due to missing required parameters in the request body or query parameters",
+                        "description": "Unable to process request due to missing required parameters in the request body or query parameters.",
                         "source": {
                             "field": "/title"
                         }
                     },
                     {
                         "code": "InvalidParameters",
-                        "description": "Unable to process request due to a malformed or invalid request body or query parameter",
+                        "description": "Unable to process request due to a malformed or invalid request body or query parameter.",
                         "source": {
                             "field": "/managed_by"
                         }
@@ -331,7 +331,7 @@ Scenario: PUT /bundles/{id} successfully updates a bundle
                 "errors": [
                     {
                         "code": "InvalidParameters",
-                        "description": "Unable to process request due to a malformed or invalid request body or query parameter",
+                        "description": "Unable to process request due to a malformed or invalid request body or query parameter.",
                         "source": {
                             "field": "/title"
                         }
@@ -364,7 +364,7 @@ Scenario: PUT /bundles/{id} successfully updates a bundle
                 "errors": [
                     {
                         "code": "InvalidParameters",
-                        "description": "Unable to process request due to a malformed or invalid request body or query parameter",
+                        "description": "Unable to process request due to a malformed or invalid request body or query parameter.",
                         "source": {
                             "field": "/scheduled_at"
                         }
@@ -397,7 +397,7 @@ Scenario: PUT /bundles/{id} successfully updates a bundle
                 "errors": [
                     {
                         "code": "InvalidParameters",
-                        "description": "Unable to process request due to a malformed or invalid request body or query parameter",
+                        "description": "Unable to process request due to a malformed or invalid request body or query parameter.",
                         "source": {
                             "field": "/scheduled_at"
                         }
@@ -430,7 +430,7 @@ Scenario: PUT /bundles/{id} successfully updates a bundle
                 "errors": [
                     {
                         "code": "InvalidParameters",
-                        "description": "Unable to process request due to a malformed or invalid request body or query parameter",
+                        "description": "Unable to process request due to a malformed or invalid request body or query parameter.",
                         "source": {
                             "field": "/scheduled_at"
                         }
@@ -462,7 +462,7 @@ Scenario: PUT /bundles/{id} successfully updates a bundle
                 "errors": [
                     {
                         "code": "InvalidParameters",
-                        "description": "Unable to process request due to a malformed or invalid request body or query parameter",
+                        "description": "Unable to process request due to a malformed or invalid request body or query parameter.",
                         "source": {
                             "field": "/state"
                         }
@@ -493,7 +493,7 @@ Scenario: PUT /bundles/{id} successfully updates a bundle
                 "errors": [
                     {
                         "code": "NotFound",
-                        "description": "The requested resource does not exist"
+                        "description": "The requested resource does not exist."
                     }
                 ]
             }

--- a/features/bundles_add.feature
+++ b/features/bundles_add.feature
@@ -81,7 +81,7 @@ Feature: Create bundle - POST /Bundles
                     "errors": [
                         {
                             "code": "BadRequest",
-                            "description": "Unable to process request due to a malformed or invalid request body or query parameter"
+                            "description": "Unable to process request due to a malformed or invalid request body or query parameter."
                         }
                     ]
                 }
@@ -113,7 +113,7 @@ Feature: Create bundle - POST /Bundles
                     "errors": [
                         {
                             "code": "InvalidParameters",
-                            "description": "Invalid time format in request body",
+                            "description": "Invalid time format in request body.",
                             "source": {
                                 "field": "scheduled_at"
                             }
@@ -148,7 +148,7 @@ Feature: Create bundle - POST /Bundles
                     "errors": [
                         {
                             "code": "InvalidParameters",
-                            "description": "scheduled_at should not be set for manual bundles",
+                            "description": "scheduled_at should not be set for manual bundles.",
                             "source": {
                                 "field": "/scheduled_at"
                             }
@@ -182,7 +182,7 @@ Feature: Create bundle - POST /Bundles
                     "errors": [
                         {
                             "code": "InvalidParameters",
-                            "description": "scheduled_at is required for scheduled bundles",
+                            "description": "scheduled_at is required for scheduled bundles.",
                             "source": {
                                 "field": "/scheduled_at"
                             }
@@ -217,7 +217,7 @@ Feature: Create bundle - POST /Bundles
                     "errors": [
                         {
                             "code": "InvalidParameters",
-                            "description": "scheduled_at cannot be in the past",
+                            "description": "scheduled_at cannot be in the past.",
                             "source": {
                                 "field": "/scheduled_at"
                             }
@@ -238,35 +238,35 @@ Feature: Create bundle - POST /Bundles
                     "errors": [
                         {
                             "code": "MissingParameters",
-                            "description": "Unable to process request due to missing required parameters in the request body or query parameters",
+                            "description": "Unable to process request due to missing required parameters in the request body or query parameters.",
                             "source": {
                                 "field": "/bundle_type"
                             }
                         },
                         {
                             "code": "MissingParameters",
-                            "description": "Unable to process request due to missing required parameters in the request body or query parameters",
+                            "description": "Unable to process request due to missing required parameters in the request body or query parameters.",
                             "source": {
                                 "field": "/preview_teams"
                             }
                         },
                         {
                             "code": "MissingParameters",
-                            "description": "Unable to process request due to missing required parameters in the request body or query parameters",
+                            "description": "Unable to process request due to missing required parameters in the request body or query parameters.",
                             "source": {
                                 "field": "/state"
                             }
                         },
                         {
                             "code": "MissingParameters",
-                            "description": "Unable to process request due to missing required parameters in the request body or query parameters",
+                            "description": "Unable to process request due to missing required parameters in the request body or query parameters.",
                             "source": {
                                 "field": "/title"
                             }
                         },
                         {
                             "code": "MissingParameters",
-                            "description": "Unable to process request due to missing required parameters in the request body or query parameters",
+                            "description": "Unable to process request due to missing required parameters in the request body or query parameters.",
                             "source": {
                                 "field": "/managed_by"
                             }
@@ -301,21 +301,21 @@ Feature: Create bundle - POST /Bundles
                     "errors": [
                         {
                             "code": "InvalidParameters",
-                            "description": "Unable to process request due to a malformed or invalid request body or query parameter",
+                            "description": "Unable to process request due to a malformed or invalid request body or query parameter.",
                             "source": {
                                 "field": "/bundle_type"
                             }
                         },
                         {
                             "code": "InvalidParameters",
-                            "description": "Unable to process request due to a malformed or invalid request body or query parameter",
+                            "description": "Unable to process request due to a malformed or invalid request body or query parameter.",
                             "source": {
                                 "field": "/state"
                             }
                         },
                         {
                             "code": "InvalidParameters",
-                            "description": "Unable to process request due to a malformed or invalid request body or query parameter",
+                            "description": "Unable to process request due to a malformed or invalid request body or query parameter.",
                             "source": {
                                 "field": "/managed_by"
                             }
@@ -350,7 +350,7 @@ Feature: Create bundle - POST /Bundles
                     "errors": [
                         {
                             "code": "Conflict",
-                            "description": "A bundle with the same title already exists",
+                            "description": "A bundle with the same title already exists.",
                             "source": {
                                 "field": "/title"
                             }
@@ -385,7 +385,7 @@ Feature: Create bundle - POST /Bundles
                     "errors": [
                         {
                             "code": "BadRequest",
-                            "description": "state not allowed to transition"
+                            "description": "state not allowed to transition."
                         }
                     ]
                 }

--- a/features/bundles_delete.feature
+++ b/features/bundles_delete.feature
@@ -131,7 +131,7 @@ Feature: Delete a bundle and all its associated content items - DELETE /bundles/
                 "errors": [
                     {
                         "code": "NotFound",
-                        "description": "The requested resource does not exist"
+                        "description": "The requested resource does not exist."
                     }
                 ]
             }

--- a/features/bundles_get_multiple.feature
+++ b/features/bundles_get_multiple.feature
@@ -195,7 +195,7 @@ Feature: List bundles - GET /Bundles
                 "errors": [
                     {
                         "code": "BadRequest",
-                        "description": "Unable to process request due to a malformed or invalid request body or query parameter",
+                        "description": "Unable to process request due to a malformed or invalid request body or query parameter.",
                         "source": {
                             "parameter": " offset"
                         }
@@ -214,7 +214,7 @@ Feature: List bundles - GET /Bundles
                 "errors": [
                     {
                         "code": "BadRequest",
-                        "description": "Unable to process request due to a malformed or invalid request body or query parameter",
+                        "description": "Unable to process request due to a malformed or invalid request body or query parameter.",
                         "source": {
                             "parameter": " limit"
                         }
@@ -280,7 +280,7 @@ Feature: List bundles - GET /Bundles
                 "errors": [
                     {
                         "code": "NotFound",
-                        "description": "The requested resource does not exist"
+                        "description": "The requested resource does not exist."
                     }
                 ]
             }
@@ -297,7 +297,7 @@ Feature: List bundles - GET /Bundles
                     "errors": [
                         {
                             "code": "InvalidParameters",
-                            "description": "Unable to process request due to a malformed or invalid request body or query parameter",
+                            "description": "Unable to process request due to a malformed or invalid request body or query parameter.",
                             "source": {
                                 "parameter": "publish_date"
                             }

--- a/features/bundles_get_single.feature
+++ b/features/bundles_get_single.feature
@@ -70,7 +70,7 @@ Feature: Get individual bundle - GET /Bundles/{bundle-id}
                 "errors": [
                     {
                         "code": "NotFound",
-                        "description": "The requested resource does not exist"
+                        "description": "The requested resource does not exist."
                     }
                 ]
             }

--- a/features/bundles_put_state.feature
+++ b/features/bundles_put_state.feature
@@ -399,7 +399,7 @@ Feature: Update Bundles functionality - PUT /bundles/{id}/state
                     "errors":[
                         {
                             "code": "BadRequest",
-                            "description": "Unable to process request due to missing If-Match header"
+                            "description": "Unable to process request due to missing If-Match header."
                         }
                     ]
                 }
@@ -423,7 +423,7 @@ Feature: Update Bundles functionality - PUT /bundles/{id}/state
                     "errors":[
                         {
                             "code": "BadRequest",
-                            "description": "Unable to process request due to a malformed or invalid request body or query parameter"
+                            "description": "Unable to process request due to a malformed or invalid request body or query parameter."
                         }
                     ]
                 }
@@ -447,7 +447,7 @@ Feature: Update Bundles functionality - PUT /bundles/{id}/state
                     "errors":[
                         {
                             "code": "BadRequest",
-                            "description": "Unable to process request due to invalid state transition"
+                            "description": "Unable to process request due to invalid state transition."
                         }
                     ]
                 }
@@ -469,7 +469,7 @@ Feature: Update Bundles functionality - PUT /bundles/{id}/state
                     "errors":[
                         {
                             "code": "NotFound",
-                            "description": "The requested resource does not exist"
+                            "description": "The requested resource does not exist."
                         }
                     ]
                 }
@@ -491,7 +491,7 @@ Feature: Update Bundles functionality - PUT /bundles/{id}/state
                     "errors":[
                         {
                             "code": "NotFound",
-                            "description": "The requested resource does not exist"
+                            "description": "The requested resource does not exist."
                         }
                     ]
                 }

--- a/features/contents_add.feature
+++ b/features/contents_add.feature
@@ -133,14 +133,14 @@ Feature: Add a dataset item to a bundle - POST /bundles/{id}/contents
                 "errors": [
                     {
                         "code": "InvalidParameters",
-                        "description": "Unable to process request due to a malformed or invalid request body or query parameter",
+                        "description": "Unable to process request due to a malformed or invalid request body or query parameter.",
                         "source": {
                             "field": "/content_type"
                         }
                     },
                     {
                         "code": "MissingParameters",
-                        "description": "Unable to process request due to missing required parameters in the request body or query parameters",
+                        "description": "Unable to process request due to missing required parameters in the request body or query parameters.",
                         "source": {
                             "field": "/links/edit"
                         }
@@ -173,7 +173,7 @@ Feature: Add a dataset item to a bundle - POST /bundles/{id}/contents
                 "errors": [
                     {
                         "code": "NotFound",
-                        "description": "Bundle not found"
+                        "description": "The requested resource does not exist."
                     }
                 ]
             }
@@ -203,7 +203,7 @@ Feature: Add a dataset item to a bundle - POST /bundles/{id}/contents
                 "errors": [
                     {
                         "code": "NotFound",
-                        "description": "The requested resource does not exist",
+                        "description": "The requested resource does not exist.",
                         "source": {
                             "field": "/metadata/dataset_id"
                         }
@@ -236,7 +236,7 @@ Feature: Add a dataset item to a bundle - POST /bundles/{id}/contents
                 "errors": [
                     {
                         "code": "NotFound",
-                        "description": "The requested resource does not exist",
+                        "description": "The requested resource does not exist.",
                         "source": {
                             "field": "/metadata/edition_id"
                         }
@@ -269,7 +269,7 @@ Feature: Add a dataset item to a bundle - POST /bundles/{id}/contents
                 "errors": [
                     {
                         "code": "NotFound",
-                        "description": "The requested resource does not exist",
+                        "description": "The requested resource does not exist.",
                         "source": {
                             "field": "/metadata/version_id"
                         }
@@ -302,7 +302,7 @@ Feature: Add a dataset item to a bundle - POST /bundles/{id}/contents
                 "errors": [
                     {
                         "code": "Conflict",
-                        "description": "Content item already exists for the given dataset, edition and version"
+                        "description": "Change rejected due to a conflict with the current resource state. A common cause is attempting to change a bundle that is already locked pending publication or has already been published."
                     }
                 ]
             }

--- a/features/contents_delete.feature
+++ b/features/contents_delete.feature
@@ -102,7 +102,7 @@ Feature: Delete a content item from a bundle - POST /bundles/{bundle-id}/content
                 "errors": [
                     {
                         "code": "NotFound",
-                        "description": "The requested resource does not exist"
+                        "description": "The requested resource does not exist."
                     }
                 ]
             }
@@ -117,7 +117,7 @@ Feature: Delete a content item from a bundle - POST /bundles/{bundle-id}/content
                 "errors": [
                     {
                         "code": "NotFound",
-                        "description": "The requested resource does not exist"
+                        "description": "The requested resource does not exist."
                     }
                 ]
             }

--- a/features/contents_get.feature
+++ b/features/contents_get.feature
@@ -237,7 +237,7 @@ Feature: Get all content items in a bundle - GET /bundles/{id}/contents
                 "errors": [
                     {
                         "code": "NotFound",
-                        "description": "Bundle not found"
+                        "description": "The requested resource does not exist."
                     }
                 ]
             }
@@ -252,7 +252,7 @@ Feature: Get all content items in a bundle - GET /bundles/{id}/contents
                 "errors": [
                     {
                         "code": "BadRequest",
-                        "description": "Unable to process request due to a malformed or invalid request body or query parameter",
+                        "description": "Unable to process request due to a malformed or invalid request body or query parameter.",
                         "source": {
                             "parameter": " offset"
                         }
@@ -271,7 +271,7 @@ Feature: Get all content items in a bundle - GET /bundles/{id}/contents
                 "errors": [
                     {
                         "code": "NotFound",
-                        "description": "The requested resource does not exist",
+                        "description": "The requested resource does not exist.",
                         "source": {
                             "field": "/metadata/dataset_id"
                         }

--- a/pagination/pagination.go
+++ b/pagination/pagination.go
@@ -183,7 +183,7 @@ func returnPaginatedResults(w http.ResponseWriter, r *http.Request, list Paginat
 		code := models.CodeInternalError
 		errInfo := &models.Error{
 			Code:        &code,
-			Description: "Failed to process the request due to an internal error",
+			Description: apierrors.ErrorDescriptionInternalError,
 		}
 		utils.HandleBundleAPIErr(w, r, http.StatusBadGateway, errInfo)
 		return
@@ -200,7 +200,7 @@ func returnPaginatedResults(w http.ResponseWriter, r *http.Request, list Paginat
 		code := models.CodeInternalError
 		errInfo := &models.Error{
 			Code:        &code,
-			Description: "Failed to process the request due to an internal error",
+			Description: apierrors.ErrorDescriptionInternalError,
 		}
 		utils.HandleBundleAPIErr(w, r, http.StatusBadGateway, errInfo)
 		return

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -479,19 +479,19 @@ responses:
     schema:
       $ref: "#/definitions/ErrorList"
   ForbiddenError:
-    description: Access denied.
+    description: "Access denied."
     schema:
       $ref: "#/definitions/ErrorList"
   InternalError:
-    description: "Failed to process the request due to an internal error"
+    description: "Failed to process the request due to an internal error."
     schema:
       $ref: "#/definitions/ErrorList"
   InvalidRequest:
-    description: Unable to process request due to a malformed or invalid request body or query parameter.
+    description: "Unable to process request due to a malformed or invalid request body or query parameter."
     schema:
       $ref: "#/definitions/ErrorList"
   MethodNotSupported:
-    description: "Attempted to call an endpoint that is not supported for this API"
+    description: "Attempted to call an endpoint that is not supported for this API."
     schema:
       $ref: "#/definitions/ErrorList"
   NotFound:
@@ -504,7 +504,7 @@ responses:
     schema:
       $ref: "#/definitions/ErrorList"
   UnauthorisedError:
-    description: Authentication information is missing or invalid
+    description: "Authentication information is missing or invalid."
     schema:
       $ref: "#/definitions/ErrorList"
 definitions:
@@ -556,7 +556,7 @@ definitions:
         example: "2025-04-04T07:00:00.000Z"
       id:
         type: string
-        description: "The bundle id"
+        description: "The bundle ID"
         readOnly: true
         minLength: 1
         maxLength: 100
@@ -655,12 +655,12 @@ definitions:
         properties:
           dataset_id:
             type: string
-            description: "The dataset id of the item in the bundle"
+            description: "The dataset ID of the item in the bundle"
             minLength: 1
             example: "cpih"
           edition_id:
             type: string
-            description: "The edition id of the dataset item in the bundle"
+            description: "The edition ID of the dataset item in the bundle"
             minLength: 1
             example: "march"
           title:
@@ -670,13 +670,13 @@ definitions:
             example: "Consumer Prices Index"
           version_id:
             type: integer
-            description: "The version id of the dataset item in the bundle"
+            description: "The version ID of the dataset item in the bundle"
             minimum: 1
             example: 1
       id:
         type: string
         readOnly: true
-        description: "An auto generated id field to identify the item"
+        description: "An auto generated ID field to identify the item"
         example: "de3bc0b6-d6c4-4e20-917e-95d7ea8c91dc"
       state:
         description: "The approval status of the item. Pre-release, this field will be hydrated from the dataset API when requested. Post-release, the bundle API will store a snapshot of the dataset metadata to be returned on subsequent requests."
@@ -721,8 +721,17 @@ definitions:
         type: string
         description: "Code representing the type of error that occurred for use by consuming systems to identify error types."
         enum:
-          - SomeError # TODO: Replace with list of actual error codes once defined
-          - AnotherError
+          - InternalError
+          - NotFound
+          - BadRequest
+          - Unauthorised
+          - Forbidden
+          - Conflict
+          - MissingParameters
+          - InvalidParameters
+          - JSONMarshalError
+          - JSONUnmarshalError
+          - WriteResponseError
       description:
         type: string
         description: "Human readable description of the error"

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -24,7 +24,7 @@ func HandleBundleAPIErr(w http.ResponseWriter, r *http.Request, httpStatusCode i
 			codeInternalError := models.CodeInternalError
 			genericError := &models.Error{
 				Code:        &codeInternalError,
-				Description: "Failed to process the request due to an internal error",
+				Description: apierrors.ErrorDescriptionInternalError,
 			}
 			httpStatusCode = http.StatusInternalServerError
 			errList.Errors = append(errList.Errors, genericError)

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/ONSdigital/dis-bundle-api/apierrors"
 	"github.com/ONSdigital/dis-bundle-api/models"
 	. "github.com/smartystreets/goconvey/convey"
 )
@@ -66,7 +67,7 @@ func TestHandleBundleAPIErr_Failure(t *testing.T) {
 				err := json.NewDecoder(w.Body).Decode(&response)
 				So(err, ShouldBeNil)
 				So(response.Errors[0].Code.String(), ShouldEqual, models.CodeInternalError.String())
-				So(response.Errors[0].Description, ShouldEqual, "Failed to process the request due to an internal error")
+				So(response.Errors[0].Description, ShouldEqual, apierrors.ErrorDescriptionInternalError)
 			})
 		})
 	})


### PR DESCRIPTION
### What

- Replace all manually typed error descriptions with common variable
- Updated swagger doc (full stop and quotations for error descriptions, id capitalised to ID, `Code` enum updated to current values)

### How to review

Check changes make sense

### Who can review

Anyone
