### PR TITLE
move dataset-api calls into application layer

### DIFF
--- a/api/contents.go
+++ b/api/contents.go
@@ -72,7 +72,7 @@ func (api *BundleAPI) postBundleContents(w http.ResponseWriter, r *http.Request)
 		authHeaders.ServiceToken = r.Header.Get("Authorization")
 	}
 
-	_, err = api.stateMachineBundleAPI.DatasetAPIClient.GetVersion(ctx, authHeaders, contentItem.Metadata.DatasetID, contentItem.Metadata.EditionID, strconv.Itoa(contentItem.Metadata.VersionID))
+	_, err = api.stateMachineBundleAPI.GetVersion(ctx, authHeaders, contentItem.Metadata.DatasetID, contentItem.Metadata.EditionID, strconv.Itoa(contentItem.Metadata.VersionID))
 	if err != nil {
 		switch {
 		case strings.Contains(err.Error(), "dataset not found"):
@@ -348,11 +348,9 @@ func (api *BundleAPI) deleteContentItem(w http.ResponseWriter, r *http.Request) 
 }
 
 func (api *BundleAPI) getBundleContents(w http.ResponseWriter, r *http.Request, limit, offset int) (contents any, totalCount int, contentErrors *models.Error) {
-	// Fetch bundle ID
 	ctx := r.Context()
 	bundleID, logData := getBundleIDAndLogData(r)
 
-	// Check if the bundle exists
 	bundleExists, err := api.stateMachineBundleAPI.CheckBundleExists(ctx, bundleID)
 	if err != nil {
 		code := models.CodeInternalError

--- a/application/application.go
+++ b/application/application.go
@@ -447,7 +447,7 @@ func (s *StateMachineBundleAPI) GetBundleContents(ctx context.Context, bundleID 
 
 	for _, contentItem := range contentResults {
 		datasetID := contentItem.Metadata.DatasetID
-		dataset, err := s.DatasetAPIClient.GetDataset(ctx, authHeaders, "", datasetID)
+		dataset, err := s.GetDataset(ctx, authHeaders, datasetID)
 
 		if err != nil {
 			log.Error(ctx, "failed to fetch dataset", err, log.Data{"dataset_id": datasetID})

--- a/application/dataset_client.go
+++ b/application/dataset_client.go
@@ -1,0 +1,16 @@
+package application
+
+import (
+	"context"
+
+	datasetAPIModels "github.com/ONSdigital/dp-dataset-api/models"
+	datasetAPISDK "github.com/ONSdigital/dp-dataset-api/sdk"
+)
+
+func (s *StateMachineBundleAPI) GetDataset(ctx context.Context, authHeaders datasetAPISDK.Headers, datasetID string) (datasetAPIModels.Dataset, error) {
+	return s.DatasetAPIClient.GetDataset(ctx, authHeaders, "", datasetID)
+}
+
+func (s *StateMachineBundleAPI) GetVersion(ctx context.Context, authHeaders datasetAPISDK.Headers, datasetID, editionID, versionID string) (datasetAPIModels.Version, error) {
+	return s.DatasetAPIClient.GetVersion(ctx, authHeaders, datasetID, editionID, versionID)
+}


### PR DESCRIPTION
### What

[Ticket](https://jira.ons.gov.uk/browse/DIS-3421)

- Moved any calls to the dataset-api into the application layer
- Some of this work has been done in a [commit](https://github.com/ONSdigital/dis-bundle-api/commit/510544d38cd462dfbdbaf35ba3b4501e73dde92e) which was included in another PR (already merged)
- The functions changed still need to be refactored so that the business logic is moved into the application package but this is not part of this ticket

### How to review

Check changes are ok
Still able to add contents to a bundle and view them 

### Who can review

Anyone
