### PR TITLE
Remove etag from bundle body

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -528,7 +528,6 @@ definitions:
       - state
       - title
       - managed_by
-      - e_tag
     properties:
       bundle_type:
         description: "The type of bundle."
@@ -613,10 +612,6 @@ definitions:
           - WAGTAIL
           - DATA-ADMIN
         example: WAGTAIL
-      e_tag:
-        description: "Auto generated ETag that defines the unique entity tag for the current state of the resource."
-        type: string
-        example: "c7e4b9a2f813d6e5f0a9d3c1e7f8b4a5d6c7e9f0"
   Contents:
     description: "A list of contents related to a bundle"
     type: object


### PR DESCRIPTION
### What

Removed etag field from the body of requests and responses as it is not required here.  It is only relevant in header information where it is already included.

### How to review

Ensure the change makes sense and the swagger spec is still valid.

### Who can review

Anyone.
