### PR TITLE
Adding service auth for connection to dataset-api

### DIFF
--- a/api/auth.go
+++ b/api/auth.go
@@ -18,6 +18,7 @@ func (api *BundleAPI) GetAuthEntityData(r *http.Request) (*models.AuthEntityData
 		Name:   "identity",
 	})
 
+	isServiceAuth := false
 	bearerToken := strings.TrimPrefix(r.Header.Get(request.AuthHeaderKey), request.BearerPrefix)
 	JWTEntityData, err := api.authMiddleware.Parse(bearerToken)
 	if err != nil {
@@ -27,9 +28,10 @@ func (api *BundleAPI) GetAuthEntityData(r *http.Request) (*models.AuthEntityData
 			return nil, err
 		} else {
 			// valid
+			isServiceAuth = true
 			JWTEntityData = &sdk.EntityData{UserID: resp.Identifier}
 		}
 	}
 
-	return models.CreateAuthEntityData(JWTEntityData, bearerToken), nil
+	return models.CreateAuthEntityData(JWTEntityData, bearerToken, isServiceAuth), nil
 }

--- a/api/bundles_test.go
+++ b/api/bundles_test.go
@@ -160,7 +160,7 @@ func GetBundleAPIWithMocksWithAuthMiddleware(datastore store.Datastore, datasetA
 			AllowedSourceStates: []string{"APPROVED"},
 		},
 	}
-	stateMachine := application.NewStateMachine(ctx, mockStates, mockTransitions, datastore)
+	stateMachine := application.NewStateMachine(ctx, mockStates, mockTransitions, datastore, cfg)
 
 	stateMachineBundleAPI := &application.StateMachineBundleAPI{
 		Datastore:        datastore,

--- a/application/state_machine_test.go
+++ b/application/state_machine_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/ONSdigital/dis-bundle-api/apierrors"
+	"github.com/ONSdigital/dis-bundle-api/config"
 	"github.com/ONSdigital/dis-bundle-api/models"
 	"github.com/ONSdigital/dis-bundle-api/store"
 	storetest "github.com/ONSdigital/dis-bundle-api/store/datastoretest"
@@ -128,6 +129,8 @@ func TestGetStateByName_Failure(t *testing.T) {
 func TestTransition_success(t *testing.T) {
 	ctx := context.Background()
 
+	cfg := &config.Config{}
+
 	states := getMockStates()
 	transitions := getMockTransitions()
 
@@ -138,7 +141,7 @@ func TestTransition_success(t *testing.T) {
 	}
 
 	mockDatasetAPIClient := &datasetAPISDKMock.ClienterMock{}
-	stateMachine := NewStateMachine(ctx, states, transitions, store.Datastore{Backend: mockedDatastore})
+	stateMachine := NewStateMachine(ctx, states, transitions, store.Datastore{Backend: mockedDatastore}, cfg)
 	stateMachineBundleAPI := Setup(store.Datastore{Backend: mockedDatastore}, stateMachine, mockDatasetAPIClient)
 
 	Convey("When transitioning from 'DRAFT' to 'IN_REVIEW'", t, func() {
@@ -207,6 +210,7 @@ func TestTransition_success(t *testing.T) {
 
 func TestTransition_failure(t *testing.T) {
 	ctx := context.Background()
+	cfg := &config.Config{}
 
 	states := getMockStates()
 	transitions := getMockTransitions()
@@ -214,7 +218,7 @@ func TestTransition_failure(t *testing.T) {
 	mockedDatastore := &storetest.StorerMock{}
 	mockDatasetAPIClient := &datasetAPISDKMock.ClienterMock{}
 
-	stateMachine := NewStateMachine(ctx, states, transitions, store.Datastore{Backend: mockedDatastore})
+	stateMachine := NewStateMachine(ctx, states, transitions, store.Datastore{Backend: mockedDatastore}, cfg)
 	stateMachineBundleAPI := Setup(store.Datastore{Backend: mockedDatastore}, stateMachine, mockDatasetAPIClient)
 
 	Convey("When transitioning from a state that is not in the transition list", t, func() {
@@ -311,6 +315,8 @@ func TestIsValidTransition(t *testing.T) {
 
 	ctx := context.Background()
 
+	cfg := &config.Config{}
+
 	states := getMockStates()
 	transitions := getMockTransitions()
 
@@ -320,7 +326,7 @@ func TestIsValidTransition(t *testing.T) {
 		},
 	}
 
-	stateMachine := NewStateMachine(ctx, states, transitions, store.Datastore{Backend: mockedDatastore})
+	stateMachine := NewStateMachine(ctx, states, transitions, store.Datastore{Backend: mockedDatastore}, cfg)
 
 	for index := range validTransitions {
 		tc := validTransitions[index]
@@ -440,6 +446,7 @@ func TestTransitionBundle_Success(t *testing.T) {
 	var createdEvents []*models.Event
 
 	ctx := context.Background()
+	cfg := &config.Config{}
 
 	states := getMockStates()
 	transitions := getMockTransitions()
@@ -521,7 +528,7 @@ func TestTransitionBundle_Success(t *testing.T) {
 		},
 	}
 
-	stateMachine := NewStateMachine(ctx, states, transitions, store.Datastore{Backend: mockedDatastore})
+	stateMachine := NewStateMachine(ctx, states, transitions, store.Datastore{Backend: mockedDatastore}, cfg)
 	stateMachineBundleAPI := Setup(store.Datastore{Backend: mockedDatastore}, stateMachine, &mockdatasetAPIClient)
 	bundle, err := stateMachine.TransitionBundle(ctx, stateMachineBundleAPI, mockBundle, &targetState, &mockAuthEntityData)
 
@@ -754,7 +761,9 @@ func TestTransitionBundle_Failure(t *testing.T) {
 			return nil, dbError
 		}
 
-		stateMachine := NewStateMachine(ctx, states, transitions, store.Datastore{Backend: mockedDatastore})
+		cfg := &config.Config{}
+
+		stateMachine := NewStateMachine(ctx, states, transitions, store.Datastore{Backend: mockedDatastore}, cfg)
 		stateMachineBundleAPI := Setup(store.Datastore{Backend: mockedDatastore}, stateMachine, &mockdatasetAPIClient)
 		bundle, err := stateMachine.TransitionBundle(ctx, stateMachineBundleAPI, mockBundle, &targetState, &mockAuthEntityData)
 		Convey("Then", t, func() {
@@ -779,7 +788,9 @@ func TestTransitionBundle_Failure(t *testing.T) {
 			return nil, nil
 		}
 
-		stateMachine := NewStateMachine(ctx, states, transitions, store.Datastore{Backend: mockedDatastore})
+		cfg := &config.Config{}
+
+		stateMachine := NewStateMachine(ctx, states, transitions, store.Datastore{Backend: mockedDatastore}, cfg)
 		stateMachineBundleAPI := Setup(store.Datastore{Backend: mockedDatastore}, stateMachine, &mockdatasetAPIClient)
 		bundle, err := stateMachine.TransitionBundle(ctx, stateMachineBundleAPI, mockBundle, &targetState, &mockAuthEntityData)
 		Convey("Then", t, func() {
@@ -805,7 +816,9 @@ func TestTransitionBundle_Failure(t *testing.T) {
 		mockedDatastore.UpdateBundleFunc = func(ctx context.Context, id string, update *models.Bundle) (*models.Bundle, error) {
 			return nil, updateBundleError
 		}
-		stateMachine := NewStateMachine(ctx, states, transitions, store.Datastore{Backend: mockedDatastore})
+
+		cfg := &config.Config{}
+		stateMachine := NewStateMachine(ctx, states, transitions, store.Datastore{Backend: mockedDatastore}, cfg)
 		stateMachineBundleAPI := Setup(store.Datastore{Backend: mockedDatastore}, stateMachine, &mockdatasetAPIClient)
 
 		bundleInstance := *mockBundle
@@ -847,7 +860,9 @@ func TestTransitionBundle_Failure(t *testing.T) {
 			return nil
 		}
 
-		stateMachine := NewStateMachine(ctx, states, transitions, store.Datastore{Backend: mockedDatastore})
+		cfg := &config.Config{}
+
+		stateMachine := NewStateMachine(ctx, states, transitions, store.Datastore{Backend: mockedDatastore}, cfg)
 		stateMachineBundleAPI := Setup(store.Datastore{Backend: mockedDatastore}, stateMachine, &mockdatasetAPIClient)
 
 		bundleInstance := *mockBundle

--- a/config/config.go
+++ b/config/config.go
@@ -19,6 +19,7 @@ type AuthConfig = authorisation.Config
 type Config struct {
 	BindAddr                   string        `envconfig:"BIND_ADDR"`
 	DatasetAPIURL              string        `envconfig:"DATASET_API_URL"`
+	DatasetServiceAuthToken    string        `envconfig:"DATASET_SERVICE_AUTH_TOKEN"`
 	GracefulShutdownTimeout    time.Duration `envconfig:"GRACEFUL_SHUTDOWN_TIMEOUT"`
 	HealthCheckInterval        time.Duration `envconfig:"HEALTHCHECK_INTERVAL"`
 	HealthCheckCriticalTimeout time.Duration `envconfig:"HEALTHCHECK_CRITICAL_TIMEOUT"`
@@ -54,6 +55,7 @@ func Get() (*Config, error) {
 	cfg = &Config{
 		BindAddr:                   ":29800",
 		DatasetAPIURL:              "http://localhost:22000",
+		DatasetServiceAuthToken:    "dataset-api-test-auth-token",
 		GracefulShutdownTimeout:    5 * time.Second,
 		HealthCheckInterval:        30 * time.Second,
 		HealthCheckCriticalTimeout: 90 * time.Second,

--- a/models/auth.go
+++ b/models/auth.go
@@ -6,13 +6,15 @@ import (
 )
 
 type AuthEntityData struct {
-	EntityData *permissionsAPISDK.EntityData
-	Headers    datasetAPISDK.Headers
+	EntityData    *permissionsAPISDK.EntityData
+	IsServiceAuth bool
+	Headers       datasetAPISDK.Headers
 }
 
-func CreateAuthEntityData(entityData *permissionsAPISDK.EntityData, serviceToken string) *AuthEntityData {
+func CreateAuthEntityData(entityData *permissionsAPISDK.EntityData, serviceToken string, isServiceAuth bool) *AuthEntityData {
 	return &AuthEntityData{
-		EntityData: entityData,
+		EntityData:    entityData,
+		IsServiceAuth: isServiceAuth,
 		Headers: datasetAPISDK.Headers{
 			ServiceToken:    serviceToken,
 			UserAccessToken: serviceToken,

--- a/service/service.go
+++ b/service/service.go
@@ -69,11 +69,11 @@ func GetListTransitions() []application.Transition {
 	return []application.Transition{draftTransition, inReviewTransition, approvedTransition, publishedTransition}
 }
 
-func GetStateMachine(ctx context.Context, datastore store.Datastore) *application.StateMachine {
+func GetStateMachine(ctx context.Context, datastore store.Datastore, cfg *config.Config) *application.StateMachine {
 	stateMachineInit.Do(func() {
 		states := []application.State{application.Draft, application.InReview, application.Approved, application.Published}
 		transitions := GetListTransitions()
-		stateMachine = application.NewStateMachine(ctx, states, transitions, datastore)
+		stateMachine = application.NewStateMachine(ctx, states, transitions, datastore, cfg)
 	})
 
 	return stateMachine
@@ -142,7 +142,7 @@ func (svc *Service) Run(ctx context.Context, buildTime, gitCommit, version strin
 	svc.datasetAPIClient = svc.ServiceList.GetDatasetAPIClient(cfg.DatasetAPIURL)
 
 	// Setup state machine
-	sm := GetStateMachine(ctx, datastore)
+	sm := GetStateMachine(ctx, datastore, cfg)
 	svc.stateMachineBundleAPI = application.Setup(datastore, sm, svc.datasetAPIClient)
 
 	// Get Permissions


### PR DESCRIPTION
### What

Added a check to see if a service auth token is provided, because if it is a specific token needs to be submitted to dataset-api in order to authenticate the request from bundle-api.

### How to review

Ensure the tests pass and the changes make sense.  For a more detailed review, run the dataset-catalogue stack locally and check that the PUT /bundles/{bundle-id}/state endpoint still works.

### Who can review

Anyone.
