### PR TITLE
Further updates to fix service auth

### DIFF
--- a/api/auth_test.go
+++ b/api/auth_test.go
@@ -52,7 +52,7 @@ func TestGetAuthEntityData_Success(t *testing.T) {
 			})
 
 			Convey("And it should contain the correct Headers", func() {
-				So(authEntityData.Headers.ServiceToken, ShouldEqual, BearerTokenValue)
+				So(authEntityData.Headers.ServiceToken, ShouldBeEmpty)
 				So(authEntityData.Headers.UserAccessToken, ShouldEqual, BearerTokenValue)
 			})
 		})

--- a/api/bundles_test.go
+++ b/api/bundles_test.go
@@ -160,7 +160,7 @@ func GetBundleAPIWithMocksWithAuthMiddleware(datastore store.Datastore, datasetA
 			AllowedSourceStates: []string{"APPROVED"},
 		},
 	}
-	stateMachine := application.NewStateMachine(ctx, mockStates, mockTransitions, datastore, cfg)
+	stateMachine := application.NewStateMachine(ctx, mockStates, mockTransitions, datastore)
 
 	stateMachineBundleAPI := &application.StateMachineBundleAPI{
 		Datastore:        datastore,

--- a/application/state_machine.go
+++ b/application/state_machine.go
@@ -7,7 +7,6 @@ import (
 	"slices"
 
 	"github.com/ONSdigital/dis-bundle-api/apierrors"
-	"github.com/ONSdigital/dis-bundle-api/config"
 	"github.com/ONSdigital/dis-bundle-api/models"
 	"github.com/ONSdigital/dis-bundle-api/store"
 	"github.com/ONSdigital/log.go/v2/log"
@@ -18,7 +17,6 @@ type StateMachine struct {
 	transitions map[string][]string
 	datastore   store.Datastore
 	ctx         context.Context
-	cfg         *config.Config
 }
 
 type Transition struct {
@@ -50,7 +48,7 @@ func getStateByName(stateName string) (*State, bool) {
 	}
 }
 
-func NewStateMachine(ctx context.Context, states []State, transitions []Transition, datastore store.Datastore, cfg *config.Config) *StateMachine {
+func NewStateMachine(ctx context.Context, states []State, transitions []Transition, datastore store.Datastore) *StateMachine {
 	statesMap := make(map[string]State)
 	for _, state := range states {
 		statesMap[state.String()] = state
@@ -66,7 +64,6 @@ func NewStateMachine(ctx context.Context, states []State, transitions []Transiti
 		transitions: transitionsMap,
 		datastore:   datastore,
 		ctx:         ctx,
-		cfg:         cfg,
 	}
 
 	return StateMachine
@@ -161,7 +158,7 @@ func (sm *StateMachine) TransitionBundle(ctx context.Context, stateMachineBundle
 	if targetState.String() == models.BundleStateApproved.String() || targetState.String() == models.BundleStatePublished.String() {
 		for index := range *contents {
 			contentItem := &(*contents)[index]
-			err = sm.transitionContentItem(ctx, contentItem, stateMachineBundleAPI, targetState, authEntityData, sm.cfg)
+			err = sm.transitionContentItem(ctx, contentItem, stateMachineBundleAPI, targetState, authEntityData)
 			if err != nil {
 				log.Warn(ctx, fmt.Sprintf("Error occurred transitioning content item for bundle: %s", err.Error()), log.Data{"bundle-id": bundle.ID, "content-item-id": contentItem.ID})
 				return nil, err
@@ -189,10 +186,7 @@ func (sm *StateMachine) TransitionBundle(ctx context.Context, stateMachineBundle
 	return updatedBundle, err
 }
 
-func (*StateMachine) transitionContentItem(ctx context.Context, contentItem *models.ContentItem, stateMachineBundleAPI *StateMachineBundleAPI, targetState *models.BundleState, authEntityData *models.AuthEntityData, cfg *config.Config) error {
-	if authEntityData.IsServiceAuth {
-		authEntityData.Headers.ServiceToken = cfg.DatasetServiceAuthToken
-	}
+func (*StateMachine) transitionContentItem(ctx context.Context, contentItem *models.ContentItem, stateMachineBundleAPI *StateMachineBundleAPI, targetState *models.BundleState, authEntityData *models.AuthEntityData) error {
 	if err := stateMachineBundleAPI.updateVersionStateForContentItem(ctx, contentItem, targetState, authEntityData.Headers); err != nil {
 		return err
 	}

--- a/application/state_machine_test.go
+++ b/application/state_machine_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/ONSdigital/dis-bundle-api/apierrors"
-	"github.com/ONSdigital/dis-bundle-api/config"
 	"github.com/ONSdigital/dis-bundle-api/models"
 	"github.com/ONSdigital/dis-bundle-api/store"
 	storetest "github.com/ONSdigital/dis-bundle-api/store/datastoretest"
@@ -129,8 +128,6 @@ func TestGetStateByName_Failure(t *testing.T) {
 func TestTransition_success(t *testing.T) {
 	ctx := context.Background()
 
-	cfg := &config.Config{}
-
 	states := getMockStates()
 	transitions := getMockTransitions()
 
@@ -141,7 +138,7 @@ func TestTransition_success(t *testing.T) {
 	}
 
 	mockDatasetAPIClient := &datasetAPISDKMock.ClienterMock{}
-	stateMachine := NewStateMachine(ctx, states, transitions, store.Datastore{Backend: mockedDatastore}, cfg)
+	stateMachine := NewStateMachine(ctx, states, transitions, store.Datastore{Backend: mockedDatastore})
 	stateMachineBundleAPI := Setup(store.Datastore{Backend: mockedDatastore}, stateMachine, mockDatasetAPIClient)
 
 	Convey("When transitioning from 'DRAFT' to 'IN_REVIEW'", t, func() {
@@ -210,7 +207,6 @@ func TestTransition_success(t *testing.T) {
 
 func TestTransition_failure(t *testing.T) {
 	ctx := context.Background()
-	cfg := &config.Config{}
 
 	states := getMockStates()
 	transitions := getMockTransitions()
@@ -218,7 +214,7 @@ func TestTransition_failure(t *testing.T) {
 	mockedDatastore := &storetest.StorerMock{}
 	mockDatasetAPIClient := &datasetAPISDKMock.ClienterMock{}
 
-	stateMachine := NewStateMachine(ctx, states, transitions, store.Datastore{Backend: mockedDatastore}, cfg)
+	stateMachine := NewStateMachine(ctx, states, transitions, store.Datastore{Backend: mockedDatastore})
 	stateMachineBundleAPI := Setup(store.Datastore{Backend: mockedDatastore}, stateMachine, mockDatasetAPIClient)
 
 	Convey("When transitioning from a state that is not in the transition list", t, func() {
@@ -315,8 +311,6 @@ func TestIsValidTransition(t *testing.T) {
 
 	ctx := context.Background()
 
-	cfg := &config.Config{}
-
 	states := getMockStates()
 	transitions := getMockTransitions()
 
@@ -326,7 +320,7 @@ func TestIsValidTransition(t *testing.T) {
 		},
 	}
 
-	stateMachine := NewStateMachine(ctx, states, transitions, store.Datastore{Backend: mockedDatastore}, cfg)
+	stateMachine := NewStateMachine(ctx, states, transitions, store.Datastore{Backend: mockedDatastore})
 
 	for index := range validTransitions {
 		tc := validTransitions[index]
@@ -446,7 +440,6 @@ func TestTransitionBundle_Success(t *testing.T) {
 	var createdEvents []*models.Event
 
 	ctx := context.Background()
-	cfg := &config.Config{}
 
 	states := getMockStates()
 	transitions := getMockTransitions()
@@ -528,7 +521,7 @@ func TestTransitionBundle_Success(t *testing.T) {
 		},
 	}
 
-	stateMachine := NewStateMachine(ctx, states, transitions, store.Datastore{Backend: mockedDatastore}, cfg)
+	stateMachine := NewStateMachine(ctx, states, transitions, store.Datastore{Backend: mockedDatastore})
 	stateMachineBundleAPI := Setup(store.Datastore{Backend: mockedDatastore}, stateMachine, &mockdatasetAPIClient)
 	bundle, err := stateMachine.TransitionBundle(ctx, stateMachineBundleAPI, mockBundle, &targetState, &mockAuthEntityData)
 
@@ -761,9 +754,7 @@ func TestTransitionBundle_Failure(t *testing.T) {
 			return nil, dbError
 		}
 
-		cfg := &config.Config{}
-
-		stateMachine := NewStateMachine(ctx, states, transitions, store.Datastore{Backend: mockedDatastore}, cfg)
+		stateMachine := NewStateMachine(ctx, states, transitions, store.Datastore{Backend: mockedDatastore})
 		stateMachineBundleAPI := Setup(store.Datastore{Backend: mockedDatastore}, stateMachine, &mockdatasetAPIClient)
 		bundle, err := stateMachine.TransitionBundle(ctx, stateMachineBundleAPI, mockBundle, &targetState, &mockAuthEntityData)
 		Convey("Then", t, func() {
@@ -788,9 +779,7 @@ func TestTransitionBundle_Failure(t *testing.T) {
 			return nil, nil
 		}
 
-		cfg := &config.Config{}
-
-		stateMachine := NewStateMachine(ctx, states, transitions, store.Datastore{Backend: mockedDatastore}, cfg)
+		stateMachine := NewStateMachine(ctx, states, transitions, store.Datastore{Backend: mockedDatastore})
 		stateMachineBundleAPI := Setup(store.Datastore{Backend: mockedDatastore}, stateMachine, &mockdatasetAPIClient)
 		bundle, err := stateMachine.TransitionBundle(ctx, stateMachineBundleAPI, mockBundle, &targetState, &mockAuthEntityData)
 		Convey("Then", t, func() {
@@ -817,8 +806,7 @@ func TestTransitionBundle_Failure(t *testing.T) {
 			return nil, updateBundleError
 		}
 
-		cfg := &config.Config{}
-		stateMachine := NewStateMachine(ctx, states, transitions, store.Datastore{Backend: mockedDatastore}, cfg)
+		stateMachine := NewStateMachine(ctx, states, transitions, store.Datastore{Backend: mockedDatastore})
 		stateMachineBundleAPI := Setup(store.Datastore{Backend: mockedDatastore}, stateMachine, &mockdatasetAPIClient)
 
 		bundleInstance := *mockBundle
@@ -860,9 +848,7 @@ func TestTransitionBundle_Failure(t *testing.T) {
 			return nil
 		}
 
-		cfg := &config.Config{}
-
-		stateMachine := NewStateMachine(ctx, states, transitions, store.Datastore{Backend: mockedDatastore}, cfg)
+		stateMachine := NewStateMachine(ctx, states, transitions, store.Datastore{Backend: mockedDatastore})
 		stateMachineBundleAPI := Setup(store.Datastore{Backend: mockedDatastore}, stateMachine, &mockdatasetAPIClient)
 
 		bundleInstance := *mockBundle

--- a/config/config.go
+++ b/config/config.go
@@ -19,7 +19,6 @@ type AuthConfig = authorisation.Config
 type Config struct {
 	BindAddr                   string        `envconfig:"BIND_ADDR"`
 	DatasetAPIURL              string        `envconfig:"DATASET_API_URL"`
-	DatasetServiceAuthToken    string        `envconfig:"DATASET_SERVICE_AUTH_TOKEN"`
 	GracefulShutdownTimeout    time.Duration `envconfig:"GRACEFUL_SHUTDOWN_TIMEOUT"`
 	HealthCheckInterval        time.Duration `envconfig:"HEALTHCHECK_INTERVAL"`
 	HealthCheckCriticalTimeout time.Duration `envconfig:"HEALTHCHECK_CRITICAL_TIMEOUT"`
@@ -55,7 +54,6 @@ func Get() (*Config, error) {
 	cfg = &Config{
 		BindAddr:                   ":29800",
 		DatasetAPIURL:              "http://localhost:22000",
-		DatasetServiceAuthToken:    "dataset-api-test-auth-token",
 		GracefulShutdownTimeout:    5 * time.Second,
 		HealthCheckInterval:        30 * time.Second,
 		HealthCheckCriticalTimeout: 90 * time.Second,

--- a/models/auth.go
+++ b/models/auth.go
@@ -12,13 +12,23 @@ type AuthEntityData struct {
 }
 
 func CreateAuthEntityData(entityData *permissionsAPISDK.EntityData, serviceToken string, isServiceAuth bool) *AuthEntityData {
+	// Need to set one value for either service token or florence token
+	// Setting them both results in the florence token being checked first which doesn't work for service auth
+	var headers datasetAPISDK.Headers
+	if isServiceAuth {
+		headers = datasetAPISDK.Headers{
+			ServiceToken: serviceToken,
+		}
+	} else {
+		headers = datasetAPISDK.Headers{
+			UserAccessToken: serviceToken,
+		}
+	}
+
 	return &AuthEntityData{
 		EntityData:    entityData,
 		IsServiceAuth: isServiceAuth,
-		Headers: datasetAPISDK.Headers{
-			ServiceToken:    serviceToken,
-			UserAccessToken: serviceToken,
-		},
+		Headers:       headers,
 	}
 }
 

--- a/service/service.go
+++ b/service/service.go
@@ -69,11 +69,11 @@ func GetListTransitions() []application.Transition {
 	return []application.Transition{draftTransition, inReviewTransition, approvedTransition, publishedTransition}
 }
 
-func GetStateMachine(ctx context.Context, datastore store.Datastore, cfg *config.Config) *application.StateMachine {
+func GetStateMachine(ctx context.Context, datastore store.Datastore) *application.StateMachine {
 	stateMachineInit.Do(func() {
 		states := []application.State{application.Draft, application.InReview, application.Approved, application.Published}
 		transitions := GetListTransitions()
-		stateMachine = application.NewStateMachine(ctx, states, transitions, datastore, cfg)
+		stateMachine = application.NewStateMachine(ctx, states, transitions, datastore)
 	})
 
 	return stateMachine
@@ -142,7 +142,7 @@ func (svc *Service) Run(ctx context.Context, buildTime, gitCommit, version strin
 	svc.datasetAPIClient = svc.ServiceList.GetDatasetAPIClient(cfg.DatasetAPIURL)
 
 	// Setup state machine
-	sm := GetStateMachine(ctx, datastore, cfg)
+	sm := GetStateMachine(ctx, datastore)
 	svc.stateMachineBundleAPI = application.Setup(datastore, sm, svc.datasetAPIClient)
 
 	// Get Permissions


### PR DESCRIPTION
### What

Reverted specific dataset auth key change.  The problem in getting authorisation from dp-dataset-api is because both the florence token and authorization header are being sent, and for service auth this is causing issues as the service auth token is not a florence token. 

This change sends one value or the other in the header.

### How to review

Ensure the change makes sense and the tests pass.

### Who can review

Anyone.
