### PR TITLE
update dcind container and update to ubuntu 22

### DIFF
--- a/Dockerfile.concourse
+++ b/Dockerfile.concourse
@@ -1,4 +1,4 @@
-FROM onsdigital/dp-concourse-tools-ubuntu-20:ubuntu20.4-rc.1
+FROM onsdigital/dp-concourse-tools-ubuntu-22:ubuntu22.4-jammy-20250126
 
 WORKDIR /app/
 

--- a/ci/component.yml
+++ b/ci/component.yml
@@ -5,7 +5,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: taylorsilva/dcind
+    repository: onsdigital/dcind
     tag: latest
 
 inputs:


### PR DESCRIPTION
### What

- Update dcind container and use Ubuntu 22 for concourse Dockerfile
- Related to https://github.com/ONSdigital/dis-bundle-api/pull/86

### How to review

CI passes and changes are ok

### Who can review

Anyone
