### PR TITLE
Feature/slack alerts on bundle publication

### DIFF
--- a/.dis-vulncheck.yml
+++ b/.dis-vulncheck.yml
@@ -1,0 +1,7 @@
+ignore:
+  - id: GO-2026-4883
+    module: github.com/docker/docker
+    reason: No fix available; transitive dependency via dp-component-test -> testcontainers-go; only used for testing, not used by service runtime.
+  - id: GO-2026-4887
+    module: github.com/docker/docker
+    reason: No fix available; transitive dependency via dp-component-test -> testcontainers-go; only used for testing, not used by service runtime.

--- a/api/bundle_update.go
+++ b/api/bundle_update.go
@@ -3,10 +3,14 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
+	"strconv"
+	"time"
 
 	"github.com/ONSdigital/dis-bundle-api/apierrors"
 	"github.com/ONSdigital/dis-bundle-api/models"
+	"github.com/ONSdigital/dis-bundle-api/slack"
 	"github.com/ONSdigital/dis-bundle-api/utils"
 	dpresponse "github.com/ONSdigital/dp-net/v3/handlers/response"
 	dphttp "github.com/ONSdigital/dp-net/v3/http"
@@ -114,9 +118,47 @@ func (api *BundleAPI) putBundle(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	var publishLogFields []slack.Field
+	var slackMessageRef *slack.MessageRef
+
+	isPublishTransition := currentBundle.State.String() == models.BundleStateApproved.String() && bundleUpdate.State.String() == models.BundleStatePublished.String()
+	publishStartTime := time.Now()
+	if isPublishTransition {
+		contentItemCount, err := api.stateMachineBundleAPI.Datastore.Backend.CountBundleContents(ctx, bundleID)
+		if err != nil {
+			// Don't block publication if we can't get the content item count.
+			// Log the error and continue with a count of 0.
+			// If it is a critical issue then a Slack alarm be raised with the failed PutBundle call.
+			log.Error(ctx, "failed to count bundle contents: continuing with count 0", err, logdata)
+		}
+
+		publishLogFields = []slack.Field{
+			{Title: "Bundle ID", Value: bundleID},
+			{Title: "Title", Value: currentBundle.Title},
+			{Title: "Type", Value: currentBundle.BundleType.String()},
+			{Title: "Number of Content Items", Value: strconv.Itoa(contentItemCount)},
+			{Title: "Publish Start Date", Value: publishStartTime.Format(utils.SlackPublishTimeFormat)},
+		}
+		logdata["slack_fields"] = publishLogFields
+
+		log.Info(ctx, "sending slack notification: Bundle publish started", logdata)
+		slackMessageRef, err = api.stateMachineBundleAPI.DataBundleSlackClient.SendPublishLog(ctx, "Bundle publish started", publishLogFields)
+		if err != nil {
+			log.Error(ctx, "failed to send slack notification: Bundle publish started", err, logdata)
+		}
+	}
+
 	updatedBundle, err := api.stateMachineBundleAPI.PutBundle(ctx, bundleID, bundleUpdate, currentBundle, authEntityData)
 	if err != nil {
 		log.Error(ctx, "putBundle endpoint: bundle update failed", err, logdata)
+
+		if isPublishTransition {
+			_, slackErr := api.stateMachineBundleAPI.DataBundleSlackClient.SendAlarm(ctx, "Failed to publish bundle", err, publishLogFields)
+			if slackErr != nil {
+				log.Error(ctx, "failed to send slack notification: Failed to publish bundle", slackErr, logdata)
+			}
+		}
+
 		switch err {
 		case apierrors.ErrInvalidTransition:
 			code := models.CodeInvalidParameters
@@ -138,6 +180,21 @@ func (api *BundleAPI) putBundle(w http.ResponseWriter, r *http.Request) {
 			api.handleInternalError(ctx, w, r, "bundle update failed", err, logdata)
 		}
 		return
+	}
+
+	if isPublishTransition {
+		publishEndTime := time.Now()
+		publishLogFields = append(publishLogFields,
+			slack.Field{Title: "Publish End Date", Value: publishEndTime.Format(utils.SlackPublishTimeFormat)},
+			slack.Field{Title: "Duration", Value: fmt.Sprintf("%.4f seconds", publishEndTime.Sub(publishStartTime).Seconds())},
+		)
+		logdata["slack_fields"] = publishLogFields
+
+		log.Info(ctx, "updating slack notification: Bundle publish completed", logdata)
+		_, err := api.stateMachineBundleAPI.DataBundleSlackClient.UpdatePublishLog(ctx, slackMessageRef, "Bundle publish completed", publishLogFields)
+		if err != nil {
+			log.Error(ctx, "failed to send slack notification: Bundle publish completed", err, logdata)
+		}
 	}
 
 	dpresponse.SetETag(w, updatedBundle.ETag)

--- a/api/bundle_update_test.go
+++ b/api/bundle_update_test.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/ONSdigital/dis-bundle-api/apierrors"
 	"github.com/ONSdigital/dis-bundle-api/models"
+	"github.com/ONSdigital/dis-bundle-api/slack"
+	slackMock "github.com/ONSdigital/dis-bundle-api/slack/mocks"
 	"github.com/ONSdigital/dis-bundle-api/store"
 	storetest "github.com/ONSdigital/dis-bundle-api/store/datastoretest"
 	datasetAPISDKMock "github.com/ONSdigital/dp-dataset-api/sdk/mocks"
@@ -42,7 +44,7 @@ func TestPutBundle_Success(t *testing.T) {
 			Title:        "Original Title",
 			BundleType:   models.BundleTypeManual,
 			ETag:         "original-etag",
-			State:        models.BundleStateDraft,
+			State:        models.BundleStateApproved,
 			CreatedAt:    &now,
 			CreatedBy:    &models.User{Email: "creator@example.com"},
 			UpdatedAt:    &now,
@@ -53,7 +55,7 @@ func TestPutBundle_Success(t *testing.T) {
 		updateRequest := &models.Bundle{
 			Title:        title1,
 			BundleType:   models.BundleTypeManual,
-			State:        models.BundleStateDraft,
+			State:        models.BundleStateApproved,
 			ManagedBy:    models.ManagedByDataAdmin,
 			PreviewTeams: &[]models.PreviewTeam{{ID: "team-1"}},
 		}
@@ -73,6 +75,9 @@ func TestPutBundle_Success(t *testing.T) {
 					return false, nil
 				}
 				return false, nil
+			},
+			CountBundleContentsFunc: func(ctx context.Context, bundleID string) (int, error) {
+				return 2, nil
 			},
 			UpdateBundleFunc: func(ctx context.Context, bundleID string, bundle *models.Bundle) (*models.Bundle, error) {
 				if bundleID == bundle1 {
@@ -113,7 +118,20 @@ func TestPutBundle_Success(t *testing.T) {
 			},
 		}
 
+		mockSlackClient := &slackMock.ClienterMock{
+			SendPublishLogFunc: func(ctx context.Context, summary string, fields []slack.Field) (*slack.MessageRef, error) {
+				return &slack.MessageRef{
+					ChannelID: "example-channel",
+					Timestamp: "example-timestamp",
+				}, nil
+			},
+			UpdatePublishLogFunc: func(ctx context.Context, ref *slack.MessageRef, summary string, fields []slack.Field) (*slack.MessageRef, error) {
+				return &slack.MessageRef{}, nil
+			},
+		}
+
 		bundleAPI := GetBundleAPIWithMocks(store.Datastore{Backend: mockedDatastore}, &datasetAPISDKMock.ClienterMock{}, mockPermissionsClient, false)
+		bundleAPI.stateMachineBundleAPI.DataBundleSlackClient = mockSlackClient
 
 		Convey("When putBundle is called with existing preview teams", func() {
 			r := httptest.NewRequest("PUT", "/bundles/bundle-1", bytes.NewReader(updateRequestJSON))
@@ -173,6 +191,39 @@ func TestPutBundle_Success(t *testing.T) {
 			Convey("And new policies should have been created for the new preview teams", func() {
 				So(len(mockPermissionsClient.GetPolicyCalls()), ShouldEqual, 3)
 				So(len(mockPermissionsClient.PostPolicyWithIDCalls()), ShouldEqual, 2)
+			})
+		})
+
+		Convey("When putBundle is called to transition from APPROVED to PUBLISHED", func() {
+			bundleRequest := updateRequest
+			bundleRequest.State = models.BundleStatePublished
+			bundleRequestJSON, err := json.Marshal(bundleRequest)
+			So(err, ShouldBeNil)
+
+			r := httptest.NewRequest("PUT", "/bundles/bundle-1", bytes.NewReader(bundleRequestJSON))
+			r = mux.SetURLVars(r, map[string]string{"bundle-id": bundle1})
+			r.Header.Set("If-Match", "original-etag")
+			r.Header.Set("Authorization", "Bearer test-auth-token")
+			w := httptest.NewRecorder()
+
+			bundleAPI.putBundle(w, r)
+
+			Convey("Then it should return 200 OK with the updated bundle", func() {
+				So(w.Code, ShouldEqual, http.StatusOK)
+				So(w.Header().Get("Content-Type"), ShouldEqual, "application/json")
+				So(w.Header().Get("Cache-Control"), ShouldEqual, "no-store")
+				So(w.Header().Get("ETag"), ShouldEqual, newEtag)
+
+				var response models.Bundle
+				err := json.NewDecoder(w.Body).Decode(&response)
+				So(err, ShouldBeNil)
+				So(response.ID, ShouldEqual, bundle1)
+				So(response.Title, ShouldEqual, title1)
+			})
+
+			Convey("And it should have sent and updated a slack publish log message", func() {
+				So(len(mockSlackClient.SendPublishLogCalls()), ShouldEqual, 1)
+				So(len(mockSlackClient.UpdatePublishLogCalls()), ShouldEqual, 1)
 			})
 		})
 	})

--- a/api/bundles_test.go
+++ b/api/bundles_test.go
@@ -20,9 +20,11 @@ import (
 	"github.com/ONSdigital/dis-bundle-api/application"
 	"github.com/ONSdigital/dis-bundle-api/config"
 	"github.com/ONSdigital/dis-bundle-api/filters"
+	"github.com/ONSdigital/dis-bundle-api/slack"
 	"github.com/ONSdigital/dis-bundle-api/utils"
 
 	"github.com/ONSdigital/dis-bundle-api/models"
+	slackMock "github.com/ONSdigital/dis-bundle-api/slack/mocks"
 	"github.com/ONSdigital/dis-bundle-api/store"
 	storetest "github.com/ONSdigital/dis-bundle-api/store/datastoretest"
 	authorisationMock "github.com/ONSdigital/dp-authorisation/v2/authorisation/mock"
@@ -747,6 +749,15 @@ func createMockStore(data *testData) *storetest.StorerMock {
 			}
 			return &items, nil
 		},
+		CountBundleContentsFunc: func(ctx context.Context, bundleID string) (int, error) {
+			count := 0
+			for _, item := range data.contentItems {
+				if item.BundleID == bundleID {
+					count++
+				}
+			}
+			return count, nil
+		},
 		UpdateContentItemStateFunc: func(ctx context.Context, contentItemID, state string) error {
 			for _, item := range data.contentItems {
 				if item.ID == contentItemID {
@@ -858,6 +869,12 @@ func TestPutBundleState_ValidTransitions(t *testing.T) {
 			additionalEventCalls = 2
 		}
 
+		var isBeingPubished bool
+		if tc.toState == models.BundleStatePublished {
+			// flag so we can assert slack client calls are made when bundle is being published
+			isBeingPubished = true
+		}
+
 		testCaseName := generateTestCaseName(PutBundleStateRoute, "PUT", fmt.Sprintf("With a valid request and a valid state transition to update state from %s", tc.name))
 		t.Run(testCaseName, func(t *testing.T) {
 			t.Parallel()
@@ -867,7 +884,19 @@ func TestPutBundleState_ValidTransitions(t *testing.T) {
 				mockStore := createMockStore(data)
 				mockDatasetAPIClient := createMockDatasetAPIClient(data)
 				mockPermissionsAPIClient := &permissionsAPISDKMock.ClienterMock{}
+				mockSlackClient := &slackMock.ClienterMock{
+					SendPublishLogFunc: func(ctx context.Context, summary string, fields []slack.Field) (*slack.MessageRef, error) {
+						return &slack.MessageRef{
+							ChannelID: "example-channel",
+							Timestamp: "example-timestamp",
+						}, nil
+					},
+					UpdatePublishLogFunc: func(ctx context.Context, ref *slack.MessageRef, summary string, fields []slack.Field) (*slack.MessageRef, error) {
+						return &slack.MessageRef{}, nil
+					},
+				}
 				bundleAPI := GetBundleAPIWithMocks(store.Datastore{Backend: mockStore}, mockDatasetAPIClient, mockPermissionsAPIClient, true)
+				bundleAPI.stateMachineBundleAPI.DataBundleSlackClient = mockSlackClient
 
 				req := createUpdateStateRequest(data.bundle.ID, data.bundle.ETag, tc.toState, nil, true)
 				rec := httptest.NewRecorder()
@@ -950,6 +979,13 @@ func TestPutBundleState_ValidTransitions(t *testing.T) {
 						event := (*data.events)[index]
 
 						So(event.Action, ShouldEqual, models.ActionUpdate)
+					}
+				})
+
+				Convey("And if the bundle is being published, a message should be sent to Slack", func() {
+					if isBeingPubished {
+						So(len(mockSlackClient.SendPublishLogCalls()), ShouldEqual, 1)
+						So(len(mockSlackClient.UpdatePublishLogCalls()), ShouldEqual, 1)
 					}
 				})
 			})

--- a/application/application.go
+++ b/application/application.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ONSdigital/dis-bundle-api/models"
 	"github.com/ONSdigital/dis-bundle-api/slack"
 	"github.com/ONSdigital/dis-bundle-api/store"
+	"github.com/ONSdigital/dis-bundle-api/utils"
 	datasetAPIModels "github.com/ONSdigital/dp-dataset-api/models"
 	datasetAPISDK "github.com/ONSdigital/dp-dataset-api/sdk"
 	permissionsAPISDK "github.com/ONSdigital/dp-permissions-api/sdk"
@@ -144,16 +145,57 @@ func (s *StateMachineBundleAPI) UpdateBundleState(ctx context.Context, bundleID,
 		return nil, err
 	}
 
+	logData := log.Data{"bundle_id": bundleID, "bundle_type": bundle.BundleType, "title": bundle.Title}
+
+	var publishLogFields []slack.Field
+	var slackMessageRef *slack.MessageRef
+	publishStartTime := time.Now()
+	isPublishTransition := bundle.State.String() == models.BundleStateApproved.String() && targetState.String() == models.BundleStatePublished.String()
+	if isPublishTransition {
+		contentItemCount, err := s.Datastore.Backend.CountBundleContents(ctx, bundleID)
+		if err != nil {
+			// Don't block publication if we can't get the content item count.
+			// Log the error and continue with a count of 0.
+			// If it is a critical issue then a Slack alarm will be raised during the state transition.
+			log.Error(ctx, "failed to count bundle contents: continuing with count 0", err, logData)
+		}
+
+		publishLogFields = []slack.Field{
+			{Title: "Bundle ID", Value: bundle.ID},
+			{Title: "Title", Value: bundle.Title},
+			{Title: "Type", Value: bundle.BundleType.String()},
+			{Title: "Number of Content Items", Value: strconv.Itoa(contentItemCount)},
+			{Title: "Publish Start Date", Value: publishStartTime.Format(utils.SlackPublishTimeFormat)},
+		}
+
+		slackMessageRef, err = s.DataBundleSlackClient.SendPublishLog(ctx, "Bundle publish started", publishLogFields)
+		if err != nil {
+			log.Error(ctx, "failed to send slack notification: Bundle publish started", err, logData)
+		}
+	}
+
 	updatedBundle, err := s.StateMachine.TransitionBundle(ctx, s, bundle, &targetState, authEntityData)
 	if err != nil {
-		// send slack notification only when there is an error going from approved to published
-		if bundle.State.String() == models.BundleStateApproved.String() && targetState.String() == models.BundleStatePublished.String() {
-			err := s.DataBundleSlackClient.SendAlarm(ctx, "Failed to publish bundle", err, map[string]interface{}{"bundle_id": bundle.ID, "bundle_type": bundle.BundleType, "title": bundle.Title})
+		if isPublishTransition {
+			_, err := s.DataBundleSlackClient.SendAlarm(ctx, "Failed to publish bundle", err, publishLogFields)
 			if err != nil {
-				log.Error(ctx, "failed to send slack notification: Failed to publish bundle", err, log.Data{"bundle_id": bundle.ID, "bundle_type": bundle.BundleType, "title": bundle.Title})
+				log.Error(ctx, "failed to send slack notification: Failed to publish bundle", err, logData)
 			}
 		}
 		return nil, err
+	}
+
+	if isPublishTransition {
+		publishEndTime := time.Now()
+		publishLogFields = append(publishLogFields,
+			slack.Field{Title: "Publish End Date", Value: publishEndTime.Format(utils.SlackPublishTimeFormat)},
+			slack.Field{Title: "Duration", Value: fmt.Sprintf("%.4f seconds", publishEndTime.Sub(publishStartTime).Seconds())},
+		)
+
+		_, err := s.DataBundleSlackClient.UpdatePublishLog(ctx, slackMessageRef, "Bundle publish completed", publishLogFields)
+		if err != nil {
+			log.Error(ctx, "failed to send slack notification: Bundle publish completed", err, logData)
+		}
 	}
 
 	return updatedBundle, nil

--- a/application/application.go
+++ b/application/application.go
@@ -167,7 +167,9 @@ func (s *StateMachineBundleAPI) UpdateBundleState(ctx context.Context, bundleID,
 			{Title: "Number of Content Items", Value: strconv.Itoa(contentItemCount)},
 			{Title: "Publish Start Date", Value: publishStartTime.Format(utils.SlackPublishTimeFormat)},
 		}
+		logData["slack_fields"] = publishLogFields
 
+		log.Info(ctx, "sending slack notification: Bundle publish started", logData)
 		slackMessageRef, err = s.DataBundleSlackClient.SendPublishLog(ctx, "Bundle publish started", publishLogFields)
 		if err != nil {
 			log.Error(ctx, "failed to send slack notification: Bundle publish started", err, logData)
@@ -191,7 +193,9 @@ func (s *StateMachineBundleAPI) UpdateBundleState(ctx context.Context, bundleID,
 			slack.Field{Title: "Publish End Date", Value: publishEndTime.Format(utils.SlackPublishTimeFormat)},
 			slack.Field{Title: "Duration", Value: fmt.Sprintf("%.4f seconds", publishEndTime.Sub(publishStartTime).Seconds())},
 		)
+		logData["slack_fields"] = publishLogFields
 
+		log.Info(ctx, "updating slack notification: Bundle publish completed", logData)
 		_, err := s.DataBundleSlackClient.UpdatePublishLog(ctx, slackMessageRef, "Bundle publish completed", publishLogFields)
 		if err != nil {
 			log.Error(ctx, "failed to send slack notification: Bundle publish completed", err, logData)

--- a/ci/audit.yml
+++ b/ci/audit.yml
@@ -5,7 +5,7 @@ image_resource:
   type: docker-image
   source:
     repository: onsdigital/dp-concourse-tools-vulncheck
-    tag: 1.26.1-vulncheck-0.3.0
+    tag: 1.26.2-vulncheck-0.3.0
 
 inputs:
   - name: dis-bundle-api

--- a/ci/audit.yml
+++ b/ci/audit.yml
@@ -5,7 +5,7 @@ image_resource:
   type: docker-image
   source:
     repository: onsdigital/dp-concourse-tools-vulncheck
-    tag: latest
+    tag: 1.26.1-vulncheck-0.3.0
 
 inputs:
   - name: dis-bundle-api

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.26.1-bookworm
+    tag: 1.26.2-bookworm
 
 inputs:
   - name: dis-bundle-api

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: latest
+    tag: 1.26.1-bookworm
 
 inputs:
   - name: dis-bundle-api

--- a/ci/component.yml
+++ b/ci/component.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: onsdigital/dp-concourse-tools-docker-go
-    tag: 1.26.1-dind-28
+    tag: 1.26.2-dind-28
 
 inputs:
   - name: dis-bundle-api

--- a/ci/component.yml
+++ b/ci/component.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: onsdigital/dp-concourse-tools-docker-go
-    tag: latest
+    tag: 1.26.1-dind-28
 
 inputs:
   - name: dis-bundle-api

--- a/ci/lint.yml
+++ b/ci/lint.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: onsdigital/dp-concourse-tools-lint-go
-    tag: latest
+    tag: 1.26.1-bookworm-golangci-lint-2
 
 inputs:
   - name: dis-bundle-api

--- a/ci/lint.yml
+++ b/ci/lint.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: onsdigital/dp-concourse-tools-lint-go
-    tag: 1.26.1-bookworm-golangci-lint-2
+    tag: 1.26.2-bookworm-golangci-lint-2
 
 inputs:
   - name: dis-bundle-api

--- a/ci/unit.yml
+++ b/ci/unit.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: onsdigital/dp-concourse-tools-docker-go
-    tag: 1.26.1-dind-28
+    tag: 1.26.2-dind-28
 
 inputs:
   - name: dis-bundle-api

--- a/ci/unit.yml
+++ b/ci/unit.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: onsdigital/dp-concourse-tools-docker-go
-    tag: latest
+    tag: 1.26.1-dind-28
 
 inputs:
   - name: dis-bundle-api

--- a/mongo/bundle_contents_store.go
+++ b/mongo/bundle_contents_store.go
@@ -209,6 +209,20 @@ func (m *Mongo) ListBundleContentIDsWithoutLimit(ctx context.Context, bundleID s
 	return results, nil
 }
 
+// CountBundleContents counts the number of content items for a specific bundle
+func (m *Mongo) CountBundleContents(ctx context.Context, bundleID string) (int, error) {
+	filter := bson.M{
+		"bundle_id": bundleID,
+	}
+
+	count, err := m.Connection.Collection(m.ActualCollectionName(config.BundleContentsCollection)).Count(ctx, filter)
+	if err != nil {
+		return 0, err
+	}
+
+	return count, nil
+}
+
 func buildListBundleContentsQuery(bundleID string) (filter, sort bson.M) {
 	filter = bson.M{}
 

--- a/mongo/bundle_contents_store_test.go
+++ b/mongo/bundle_contents_store_test.go
@@ -564,3 +564,46 @@ func TestUpdateContentItemState_Idempotent(t *testing.T) {
 		})
 	})
 }
+
+func TestCountBundleContents(t *testing.T) {
+	ctx := context.Background()
+
+	Convey("Given the db connection is initialized correctly", t, func() {
+		mongodb, err := getTestMongoDB(ctx, t)
+		So(err, ShouldBeNil)
+
+		err = setupBundleContentsTestData(ctx, mongodb)
+		So(err, ShouldBeNil)
+
+		Convey("When CountBundleContents is called with a valid bundle ID", func() {
+			bundleID := Bundle1ID
+			count, err := mongodb.CountBundleContents(ctx, bundleID)
+
+			Convey("Then it returns the correct count without error", func() {
+				So(err, ShouldBeNil)
+				So(count, ShouldEqual, 2)
+			})
+		})
+
+		Convey("When CountBundleContents is called with a non-existent bundle ID", func() {
+			bundleID := "non-existent-bundle-id"
+			count, err := mongodb.CountBundleContents(ctx, bundleID)
+
+			Convey("Then it returns zero count without error", func() {
+				So(err, ShouldBeNil)
+				So(count, ShouldEqual, 0)
+			})
+		})
+
+		Convey("When CountBundleContents is called and the connection is closed", func() {
+			mongodb.Connection.Close(ctx)
+			bundleID := Bundle1ID
+			_, err := mongodb.CountBundleContents(ctx, bundleID)
+
+			Convey("Then it returns an error", func() {
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldContainSubstring, "client is disconnected")
+			})
+		})
+	})
+}

--- a/slack/client.go
+++ b/slack/client.go
@@ -35,55 +35,101 @@ func New(slackConfig *SlackConfig, apiToken string, enabled bool) (Clienter, err
 }
 
 // SendAlarm sends an error notification to the configured Slack alarm channel.
-func (c *Client) SendAlarm(ctx context.Context, summary string, err error, details map[string]interface{}) error {
-	return c.doSendMessage(ctx, c.channels.AlarmChannel, RedColour, AlarmEmoji, summary, buildAttachmentFields(err, details))
+func (c *Client) SendAlarm(ctx context.Context, summary string, err error, fields []Field) (*MessageRef, error) {
+	return c.doSendMessage(ctx, c.channels.AlarmChannel, RedColour, AlarmEmoji, summary, buildAttachmentFields(err, fields))
 }
 
 // SendWarning sends a warning notification to the configured Slack warning channel.
-func (c *Client) SendWarning(ctx context.Context, summary string, details map[string]interface{}) error {
-	return c.doSendMessage(ctx, c.channels.WarningChannel, YellowColour, WarningEmoji, summary, buildAttachmentFields(nil, details))
+func (c *Client) SendWarning(ctx context.Context, summary string, fields []Field) (*MessageRef, error) {
+	return c.doSendMessage(ctx, c.channels.WarningChannel, YellowColour, WarningEmoji, summary, buildAttachmentFields(nil, fields))
 }
 
 // SendInfo sends an info notification to the configured Slack info channel.
-func (c *Client) SendInfo(ctx context.Context, summary string, details map[string]interface{}) error {
-	return c.doSendMessage(ctx, c.channels.InfoChannel, GreenColour, InfoEmoji, summary, buildAttachmentFields(nil, details))
+func (c *Client) SendInfo(ctx context.Context, summary string, fields []Field) (*MessageRef, error) {
+	return c.doSendMessage(ctx, c.channels.InfoChannel, GreenColour, InfoEmoji, summary, buildAttachmentFields(nil, fields))
+}
+
+// SendPublishLog sends a publish log notification to the configured Slack publish log channel.
+func (c *Client) SendPublishLog(ctx context.Context, summary string, fields []Field) (*MessageRef, error) {
+	return c.doSendMessage(ctx, c.channels.PublishLogChannel, YellowColour, TimerEmoji, summary, buildAttachmentFields(nil, fields))
+}
+
+// UpdatePublishLog updates a previously sent publish log message.
+// The colour is set to green as we assume that a publish log is only updated when the publish is successful.
+func (c *Client) UpdatePublishLog(ctx context.Context, ref *MessageRef, summary string, fields []Field) (*MessageRef, error) {
+	return c.doUpdateMessage(ctx, ref, GreenColour, TickEmoji, summary, buildAttachmentFields(nil, fields))
 }
 
 // doSendMessage is a helper function to send a message to a specified Slack channel with given parameters
-func (c *Client) doSendMessage(ctx context.Context, channel string, color Colour, emoji Emoji, summary string, fields []slack.AttachmentField) error {
+func (c *Client) doSendMessage(ctx context.Context, channel string, color Colour, emoji Emoji, summary string, fields []slack.AttachmentField) (*MessageRef, error) {
 	attachment := slack.Attachment{
 		Color:  color.String(),
 		Fields: fields,
 	}
 
-	_, _, err := c.client.PostMessageContext(
+	channelID, timestamp, err := c.client.PostMessageContext(
 		ctx,
 		channel,
 		slack.MsgOptionText(fmt.Sprintf("%s %s", emoji.String(), summary), false),
 		slack.MsgOptionAttachments(attachment),
 	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send message to Slack channel %s: %w", channel, err)
+	}
 
-	return err
+	return &MessageRef{ChannelID: channelID, Timestamp: timestamp}, nil
+}
+
+// doUpdateMessage updates a Slack message using its reference.
+func (c *Client) doUpdateMessage(ctx context.Context, ref *MessageRef, color Colour, emoji Emoji, summary string, fields []slack.AttachmentField) (*MessageRef, error) {
+	if ref == nil {
+		return nil, errMissingMessageRef
+	}
+	if ref.ChannelID == "" {
+		return nil, errMissingMessageRefChannel
+	}
+	if ref.Timestamp == "" {
+		return nil, errMissingMessageRefTimestamp
+	}
+
+	attachment := slack.Attachment{
+		Color:  color.String(),
+		Fields: fields,
+	}
+
+	channelID, timestamp, _, err := c.client.UpdateMessageContext(
+		ctx,
+		ref.ChannelID,
+		ref.Timestamp,
+		slack.MsgOptionText(fmt.Sprintf("%s %s", emoji.String(), summary), false),
+		slack.MsgOptionAttachments(attachment),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update message in Slack channel %s: %w", ref.ChannelID, err)
+	}
+
+	return &MessageRef{ChannelID: channelID, Timestamp: timestamp}, nil
 }
 
 // buildAttachmentFields constructs Slack attachment fields from the given error and details.
 // If err is not nil, it sets the first field to the error message
-func buildAttachmentFields(err error, details map[string]interface{}) []slack.AttachmentField {
-	fields := []slack.AttachmentField{}
+func buildAttachmentFields(err error, fields []Field) []slack.AttachmentField {
+	attachmentFields := []slack.AttachmentField{}
 
 	if err != nil {
-		fields = append(fields, slack.AttachmentField{
+		attachmentFields = append(attachmentFields, slack.AttachmentField{
 			Title: "Error",
 			Value: err.Error(),
 		})
 	}
 
-	for key, value := range details {
-		fields = append(fields, slack.AttachmentField{
-			Title: key,
-			Value: fmt.Sprintf("%v", value),
+	for _, field := range fields {
+		attachmentFields = append(attachmentFields, slack.AttachmentField{
+			Title: field.Title,
+			Value: field.Value,
+			Short: true,
 		})
 	}
 
-	return fields
+	return attachmentFields
 }

--- a/slack/client_test.go
+++ b/slack/client_test.go
@@ -14,13 +14,15 @@ import (
 var (
 	validSlackConfig = &SlackConfig{
 		Channels: Channels{
-			InfoChannel:    "info-channel",
-			WarningChannel: "warning-channel",
-			AlarmChannel:   "alarm-channel",
+			InfoChannel:       "info-channel",
+			WarningChannel:    "warning-channel",
+			AlarmChannel:      "alarm-channel",
+			PublishLogChannel: "publish-log-channel",
 		},
 	}
-	validAPIToken      = "valid-api-token"
-	postMessageAPIPath = "/api/chat.postMessage"
+	validAPIToken        = "valid-api-token"
+	postMessageAPIPath   = "/api/chat.postMessage"
+	updateMessageAPIPath = "/api/chat.update"
 )
 
 func getMockHTTPServer(expectedPath string) *httptest.Server {
@@ -31,7 +33,7 @@ func getMockHTTPServer(expectedPath string) *httptest.Server {
 		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"ok": true}`))
+		w.Write([]byte(`{"ok": true, "channel": "test-channel", "ts": "1234.5678"}`))
 	}))
 	return testServer
 }
@@ -96,7 +98,7 @@ func TestNew(t *testing.T) {
 	})
 }
 
-// This test covers the doSendMessage method indirectly through SendInfo, SendWarning, and SendAlarm.
+// This test covers the doSendMessage method indirectly through SendInfo, SendWarning, SendAlarm and SendPublishLog.
 // It verifies that messages can be sent to Slack without errors and uses a mock HTTP server to simulate Slack's API.
 func TestClient_DoSendMessage(t *testing.T) {
 	Convey("Given a mock Slack Client and valid parameters", t, func() {
@@ -115,40 +117,184 @@ func TestClient_DoSendMessage(t *testing.T) {
 		}
 
 		Convey("When doSendMessage is called through SendInfo", func() {
-			err := client.SendInfo(context.Background(), "Test Summary", map[string]interface{}{"key": "value"})
+			ref, err := client.SendInfo(context.Background(), "Test Summary", []Field{{Title: "key", Value: "value"}})
 
 			Convey("Then no error is returned", func() {
 				So(err, ShouldBeNil)
+				So(ref, ShouldNotBeNil)
+				So(ref.ChannelID, ShouldEqual, "test-channel")
+				So(ref.Timestamp, ShouldEqual, "1234.5678")
 			})
 		})
 
 		Convey("When doSendMessage is called through SendWarning", func() {
-			err := client.SendWarning(context.Background(), "Test Summary", map[string]interface{}{"key": "value"})
+			ref, err := client.SendWarning(context.Background(), "Test Summary", []Field{{Title: "key", Value: "value"}})
 
 			Convey("Then no error is returned", func() {
 				So(err, ShouldBeNil)
+				So(ref, ShouldNotBeNil)
+				So(ref.ChannelID, ShouldEqual, "test-channel")
+				So(ref.Timestamp, ShouldEqual, "1234.5678")
 			})
 		})
 
 		Convey("When doSendMessage is called through SendAlarm", func() {
-			err := client.SendAlarm(context.Background(), "Test Summary", errors.New("test error"), map[string]interface{}{"key": "value"})
+			ref, err := client.SendAlarm(context.Background(), "Test Summary", errors.New("test error"), []Field{{Title: "key", Value: "value"}})
 
 			Convey("Then no error is returned", func() {
 				So(err, ShouldBeNil)
+				So(ref, ShouldNotBeNil)
+				So(ref.ChannelID, ShouldEqual, "test-channel")
+				So(ref.Timestamp, ShouldEqual, "1234.5678")
+			})
+		})
+
+		Convey("When doSendMessage is called through SendPublishLog", func() {
+			ref, err := client.SendPublishLog(context.Background(), "Test Summary", []Field{{Title: "key", Value: "value"}})
+
+			Convey("Then no error is returned", func() {
+				So(err, ShouldBeNil)
+				So(ref, ShouldNotBeNil)
+				So(ref.ChannelID, ShouldEqual, "test-channel")
+				So(ref.Timestamp, ShouldEqual, "1234.5678")
+			})
+		})
+	})
+
+	Convey("Given a Slack Client that returns an error", t, func() {
+		testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte(`{"ok": false, "error": "server_error"}`))
+		}))
+		defer testServer.Close()
+
+		slackClient := slack.New(
+			validAPIToken,
+			slack.OptionHTTPClient(testServer.Client()),
+			slack.OptionAPIURL(testServer.URL+"/api/"),
+		)
+
+		client := &Client{
+			client:   slackClient,
+			channels: validSlackConfig.Channels,
+		}
+
+		Convey("When SendInfo is called", func() {
+			ref, err := client.SendInfo(context.Background(), "Test Summary", nil)
+
+			Convey("Then a wrapped error is returned", func() {
+				So(ref, ShouldBeNil)
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldContainSubstring, "failed to send message to Slack channel")
+			})
+		})
+	})
+}
+
+// This test covers the doUpdateMessage method indirectly through UpdatePublishLog.
+// It verifies that message updates can be sent to Slack without errors and uses a mock HTTP server to simulate Slack's API.
+func TestClient_DoUpdateMessage(t *testing.T) {
+	Convey("Given a mock Slack Client and valid parameters", t, func() {
+		testServer := getMockHTTPServer(updateMessageAPIPath)
+		defer testServer.Close()
+
+		slackClient := slack.New(
+			validAPIToken,
+			slack.OptionHTTPClient(testServer.Client()),
+			slack.OptionAPIURL(testServer.URL+"/api/"),
+		)
+
+		client := &Client{
+			client:   slackClient,
+			channels: validSlackConfig.Channels,
+		}
+
+		ref := &MessageRef{ChannelID: "test-channel", Timestamp: "1234.5678"}
+
+		Convey("When doUpdateMessage is called through UpdatePublishLog", func() {
+			updatedRef, err := client.UpdatePublishLog(context.Background(), ref, "Updated Summary", []Field{{Title: "key", Value: "value"}})
+
+			Convey("Then no error is returned", func() {
+				So(err, ShouldBeNil)
+				So(updatedRef, ShouldNotBeNil)
+				So(updatedRef.ChannelID, ShouldEqual, "test-channel")
+				So(updatedRef.Timestamp, ShouldEqual, "1234.5678")
+			})
+		})
+	})
+
+	Convey("Given a Slack Client that returns an error", t, func() {
+		testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte(`{"ok": false, "error": "server_error"}`))
+		}))
+		defer testServer.Close()
+
+		slackClient := slack.New(
+			validAPIToken,
+			slack.OptionHTTPClient(testServer.Client()),
+			slack.OptionAPIURL(testServer.URL+"/api/"),
+		)
+
+		client := &Client{
+			client:   slackClient,
+			channels: validSlackConfig.Channels,
+		}
+
+		ref := &MessageRef{ChannelID: "test-channel", Timestamp: "1234.5678"}
+
+		Convey("When UpdatePublishLog is called", func() {
+			updatedRef, err := client.UpdatePublishLog(context.Background(), ref, "Updated Summary", nil)
+
+			Convey("Then a wrapped error is returned", func() {
+				So(updatedRef, ShouldBeNil)
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldContainSubstring, "failed to update message in Slack channel")
+			})
+		})
+	})
+
+	Convey("Given invalid message references", t, func() {
+		client := &Client{}
+
+		Convey("When UpdatePublishLog is called with a nil ref", func() {
+			updatedRef, err := client.UpdatePublishLog(context.Background(), nil, "Updated Summary", nil)
+
+			Convey("Then a missing ref error is returned", func() {
+				So(err, ShouldEqual, errMissingMessageRef)
+				So(updatedRef, ShouldBeNil)
+			})
+		})
+
+		Convey("When UpdatePublishLog is called with an empty channel", func() {
+			updatedRef, err := client.UpdatePublishLog(context.Background(), &MessageRef{Timestamp: "1234.5678"}, "Updated Summary", nil)
+
+			Convey("Then a missing channel error is returned", func() {
+				So(err, ShouldEqual, errMissingMessageRefChannel)
+				So(updatedRef, ShouldBeNil)
+			})
+		})
+
+		Convey("When UpdatePublishLog is called with an empty timestamp", func() {
+			updatedRef, err := client.UpdatePublishLog(context.Background(), &MessageRef{ChannelID: "test-channel"}, "Updated Summary", nil)
+
+			Convey("Then a missing timestamp error is returned", func() {
+				So(err, ShouldEqual, errMissingMessageRefTimestamp)
+				So(updatedRef, ShouldBeNil)
 			})
 		})
 	})
 }
 
 func TestBuildAttachmentFields(t *testing.T) {
-	Convey("Given an error and details", t, func() {
+	Convey("Given an error and fields", t, func() {
 		err := errors.New("example error")
-		details := map[string]interface{}{
-			"key1": "value1",
+		fields := []Field{
+			{Title: "key1", Value: "value1"},
 		}
 
 		Convey("When buildAttachmentFields is called", func() {
-			fields := buildAttachmentFields(err, details)
+			fields := buildAttachmentFields(err, fields)
 
 			Convey("Then the returned fields contain the error and details", func() {
 				So(len(fields), ShouldEqual, 2)
@@ -160,13 +306,13 @@ func TestBuildAttachmentFields(t *testing.T) {
 		})
 	})
 
-	Convey("Given no error and details", t, func() {
-		details := map[string]interface{}{
-			"key1": 1,
+	Convey("Given no error and fields", t, func() {
+		fields := []Field{
+			{Title: "key1", Value: "1"},
 		}
 
 		Convey("When buildAttachmentFields is called", func() {
-			fields := buildAttachmentFields(nil, details)
+			fields := buildAttachmentFields(nil, fields)
 
 			Convey("Then the returned fields contain only the details", func() {
 				So(len(fields), ShouldEqual, 1)
@@ -176,7 +322,7 @@ func TestBuildAttachmentFields(t *testing.T) {
 		})
 	})
 
-	Convey("Given an error and no details", t, func() {
+	Convey("Given an error and no fields", t, func() {
 		err := errors.New("example error")
 
 		Convey("When buildAttachmentFields is called", func() {
@@ -190,7 +336,7 @@ func TestBuildAttachmentFields(t *testing.T) {
 		})
 	})
 
-	Convey("Given no error and no details", t, func() {
+	Convey("Given no error and no fields", t, func() {
 		Convey("When buildAttachmentFields is called", func() {
 			fields := buildAttachmentFields(nil, nil)
 

--- a/slack/config.go
+++ b/slack/config.go
@@ -7,9 +7,10 @@ type SlackConfig struct {
 
 // Channels holds the Slack channel names for different notification levels
 type Channels struct {
-	InfoChannel    string `envconfig:"SLACK_INFO_CHANNEL"`
-	WarningChannel string `envconfig:"SLACK_WARNING_CHANNEL"`
-	AlarmChannel   string `envconfig:"SLACK_ALARM_CHANNEL"`
+	InfoChannel       string `envconfig:"SLACK_INFO_CHANNEL"`
+	WarningChannel    string `envconfig:"SLACK_WARNING_CHANNEL"`
+	AlarmChannel      string `envconfig:"SLACK_ALARM_CHANNEL"`
+	PublishLogChannel string `envconfig:"SLACK_PUBLISH_LOG_CHANNEL"`
 }
 
 // validateSlackConfig checks that all required fields are set in the SlackConfig
@@ -25,6 +26,9 @@ func validateSlackConfig(cfg *SlackConfig, apiToken string) error {
 	}
 	if cfg.Channels.AlarmChannel == "" {
 		return errMissingAlarmChannel
+	}
+	if cfg.Channels.PublishLogChannel == "" {
+		return errMissingPublishLogChannel
 	}
 	return nil
 }

--- a/slack/config_test.go
+++ b/slack/config_test.go
@@ -51,13 +51,26 @@ func TestValidateSlackConfig(t *testing.T) {
 				expectErr: errMissingAlarmChannel,
 			},
 			{
-				name:     "a valid config",
+				name:     "missing a PublishLogChannel",
 				apiToken: validAPIToken,
 				config: &SlackConfig{
 					Channels: Channels{
 						InfoChannel:    "info-channel",
 						WarningChannel: "warning-channel",
 						AlarmChannel:   "alarm-channel",
+					},
+				},
+				expectErr: errMissingPublishLogChannel,
+			},
+			{
+				name:     "a valid config",
+				apiToken: validAPIToken,
+				config: &SlackConfig{
+					Channels: Channels{
+						InfoChannel:       "info-channel",
+						WarningChannel:    "warning-channel",
+						AlarmChannel:      "alarm-channel",
+						PublishLogChannel: "publish-log-channel",
 					},
 				},
 				expectErr: nil,

--- a/slack/errors.go
+++ b/slack/errors.go
@@ -5,9 +5,15 @@ import "errors"
 // Predefined errors used within the slack package
 var (
 	// configuration errors
-	errNilSlackConfig        = errors.New("slack configuration is nil")
-	errMissingAPIToken       = errors.New("slack API token is missing")
-	errMissingInfoChannel    = errors.New("slack info channel is missing")
-	errMissingWarningChannel = errors.New("slack warning channel is missing")
-	errMissingAlarmChannel   = errors.New("slack alarm channel is missing")
+	errNilSlackConfig           = errors.New("slack configuration is nil")
+	errMissingAPIToken          = errors.New("slack API token is missing")
+	errMissingInfoChannel       = errors.New("slack info channel is missing")
+	errMissingWarningChannel    = errors.New("slack warning channel is missing")
+	errMissingAlarmChannel      = errors.New("slack alarm channel is missing")
+	errMissingPublishLogChannel = errors.New("slack publish log channel is missing")
+
+	// MessageRef errors
+	errMissingMessageRef          = errors.New("slack message reference is missing")
+	errMissingMessageRefChannel   = errors.New("slack message reference channel is missing")
+	errMissingMessageRefTimestamp = errors.New("slack message reference timestamp is missing")
 )

--- a/slack/interface.go
+++ b/slack/interface.go
@@ -8,7 +8,9 @@ import (
 
 // Clienter represents an interface for a generic Client
 type Clienter interface {
-	SendAlarm(ctx context.Context, summary string, err error, details map[string]interface{}) error
-	SendWarning(ctx context.Context, summary string, details map[string]interface{}) error
-	SendInfo(ctx context.Context, summary string, details map[string]interface{}) error
+	SendAlarm(ctx context.Context, summary string, err error, fields []Field) (*MessageRef, error)
+	SendWarning(ctx context.Context, summary string, fields []Field) (*MessageRef, error)
+	SendInfo(ctx context.Context, summary string, fields []Field) (*MessageRef, error)
+	SendPublishLog(ctx context.Context, summary string, fields []Field) (*MessageRef, error)
+	UpdatePublishLog(ctx context.Context, ref *MessageRef, summary string, fields []Field) (*MessageRef, error)
 }

--- a/slack/mocks/client.go
+++ b/slack/mocks/client.go
@@ -19,14 +19,20 @@ var _ slack.Clienter = &ClienterMock{}
 //
 //		// make and configure a mocked slack.Clienter
 //		mockedClienter := &ClienterMock{
-//			SendAlarmFunc: func(ctx context.Context, summary string, err error, details map[string]interface{}) error {
+//			SendAlarmFunc: func(ctx context.Context, summary string, err error, fields []slack.Field) (*slack.MessageRef, error) {
 //				panic("mock out the SendAlarm method")
 //			},
-//			SendInfoFunc: func(ctx context.Context, summary string, details map[string]interface{}) error {
+//			SendInfoFunc: func(ctx context.Context, summary string, fields []slack.Field) (*slack.MessageRef, error) {
 //				panic("mock out the SendInfo method")
 //			},
-//			SendWarningFunc: func(ctx context.Context, summary string, details map[string]interface{}) error {
+//			SendPublishLogFunc: func(ctx context.Context, summary string, fields []slack.Field) (*slack.MessageRef, error) {
+//				panic("mock out the SendPublishLog method")
+//			},
+//			SendWarningFunc: func(ctx context.Context, summary string, fields []slack.Field) (*slack.MessageRef, error) {
 //				panic("mock out the SendWarning method")
+//			},
+//			UpdatePublishLogFunc: func(ctx context.Context, ref *slack.MessageRef, summary string, fields []slack.Field) (*slack.MessageRef, error) {
+//				panic("mock out the UpdatePublishLog method")
 //			},
 //		}
 //
@@ -36,13 +42,19 @@ var _ slack.Clienter = &ClienterMock{}
 //	}
 type ClienterMock struct {
 	// SendAlarmFunc mocks the SendAlarm method.
-	SendAlarmFunc func(ctx context.Context, summary string, err error, details map[string]interface{}) error
+	SendAlarmFunc func(ctx context.Context, summary string, err error, fields []slack.Field) (*slack.MessageRef, error)
 
 	// SendInfoFunc mocks the SendInfo method.
-	SendInfoFunc func(ctx context.Context, summary string, details map[string]interface{}) error
+	SendInfoFunc func(ctx context.Context, summary string, fields []slack.Field) (*slack.MessageRef, error)
+
+	// SendPublishLogFunc mocks the SendPublishLog method.
+	SendPublishLogFunc func(ctx context.Context, summary string, fields []slack.Field) (*slack.MessageRef, error)
 
 	// SendWarningFunc mocks the SendWarning method.
-	SendWarningFunc func(ctx context.Context, summary string, details map[string]interface{}) error
+	SendWarningFunc func(ctx context.Context, summary string, fields []slack.Field) (*slack.MessageRef, error)
+
+	// UpdatePublishLogFunc mocks the UpdatePublishLog method.
+	UpdatePublishLogFunc func(ctx context.Context, ref *slack.MessageRef, summary string, fields []slack.Field) (*slack.MessageRef, error)
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -54,8 +66,8 @@ type ClienterMock struct {
 			Summary string
 			// Err is the err argument value.
 			Err error
-			// Details is the details argument value.
-			Details map[string]interface{}
+			// Fields is the fields argument value.
+			Fields []slack.Field
 		}
 		// SendInfo holds details about calls to the SendInfo method.
 		SendInfo []struct {
@@ -63,8 +75,17 @@ type ClienterMock struct {
 			Ctx context.Context
 			// Summary is the summary argument value.
 			Summary string
-			// Details is the details argument value.
-			Details map[string]interface{}
+			// Fields is the fields argument value.
+			Fields []slack.Field
+		}
+		// SendPublishLog holds details about calls to the SendPublishLog method.
+		SendPublishLog []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// Summary is the summary argument value.
+			Summary string
+			// Fields is the fields argument value.
+			Fields []slack.Field
 		}
 		// SendWarning holds details about calls to the SendWarning method.
 		SendWarning []struct {
@@ -72,17 +93,30 @@ type ClienterMock struct {
 			Ctx context.Context
 			// Summary is the summary argument value.
 			Summary string
-			// Details is the details argument value.
-			Details map[string]interface{}
+			// Fields is the fields argument value.
+			Fields []slack.Field
+		}
+		// UpdatePublishLog holds details about calls to the UpdatePublishLog method.
+		UpdatePublishLog []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// Ref is the ref argument value.
+			Ref *slack.MessageRef
+			// Summary is the summary argument value.
+			Summary string
+			// Fields is the fields argument value.
+			Fields []slack.Field
 		}
 	}
-	lockSendAlarm   sync.RWMutex
-	lockSendInfo    sync.RWMutex
-	lockSendWarning sync.RWMutex
+	lockSendAlarm        sync.RWMutex
+	lockSendInfo         sync.RWMutex
+	lockSendPublishLog   sync.RWMutex
+	lockSendWarning      sync.RWMutex
+	lockUpdatePublishLog sync.RWMutex
 }
 
 // SendAlarm calls SendAlarmFunc.
-func (mock *ClienterMock) SendAlarm(ctx context.Context, summary string, err error, details map[string]interface{}) error {
+func (mock *ClienterMock) SendAlarm(ctx context.Context, summary string, err error, fields []slack.Field) (*slack.MessageRef, error) {
 	if mock.SendAlarmFunc == nil {
 		panic("ClienterMock.SendAlarmFunc: method is nil but Clienter.SendAlarm was just called")
 	}
@@ -90,17 +124,17 @@ func (mock *ClienterMock) SendAlarm(ctx context.Context, summary string, err err
 		Ctx     context.Context
 		Summary string
 		Err     error
-		Details map[string]interface{}
+		Fields  []slack.Field
 	}{
 		Ctx:     ctx,
 		Summary: summary,
 		Err:     err,
-		Details: details,
+		Fields:  fields,
 	}
 	mock.lockSendAlarm.Lock()
 	mock.calls.SendAlarm = append(mock.calls.SendAlarm, callInfo)
 	mock.lockSendAlarm.Unlock()
-	return mock.SendAlarmFunc(ctx, summary, err, details)
+	return mock.SendAlarmFunc(ctx, summary, err, fields)
 }
 
 // SendAlarmCalls gets all the calls that were made to SendAlarm.
@@ -111,13 +145,13 @@ func (mock *ClienterMock) SendAlarmCalls() []struct {
 	Ctx     context.Context
 	Summary string
 	Err     error
-	Details map[string]interface{}
+	Fields  []slack.Field
 } {
 	var calls []struct {
 		Ctx     context.Context
 		Summary string
 		Err     error
-		Details map[string]interface{}
+		Fields  []slack.Field
 	}
 	mock.lockSendAlarm.RLock()
 	calls = mock.calls.SendAlarm
@@ -126,23 +160,23 @@ func (mock *ClienterMock) SendAlarmCalls() []struct {
 }
 
 // SendInfo calls SendInfoFunc.
-func (mock *ClienterMock) SendInfo(ctx context.Context, summary string, details map[string]interface{}) error {
+func (mock *ClienterMock) SendInfo(ctx context.Context, summary string, fields []slack.Field) (*slack.MessageRef, error) {
 	if mock.SendInfoFunc == nil {
 		panic("ClienterMock.SendInfoFunc: method is nil but Clienter.SendInfo was just called")
 	}
 	callInfo := struct {
 		Ctx     context.Context
 		Summary string
-		Details map[string]interface{}
+		Fields  []slack.Field
 	}{
 		Ctx:     ctx,
 		Summary: summary,
-		Details: details,
+		Fields:  fields,
 	}
 	mock.lockSendInfo.Lock()
 	mock.calls.SendInfo = append(mock.calls.SendInfo, callInfo)
 	mock.lockSendInfo.Unlock()
-	return mock.SendInfoFunc(ctx, summary, details)
+	return mock.SendInfoFunc(ctx, summary, fields)
 }
 
 // SendInfoCalls gets all the calls that were made to SendInfo.
@@ -152,12 +186,12 @@ func (mock *ClienterMock) SendInfo(ctx context.Context, summary string, details 
 func (mock *ClienterMock) SendInfoCalls() []struct {
 	Ctx     context.Context
 	Summary string
-	Details map[string]interface{}
+	Fields  []slack.Field
 } {
 	var calls []struct {
 		Ctx     context.Context
 		Summary string
-		Details map[string]interface{}
+		Fields  []slack.Field
 	}
 	mock.lockSendInfo.RLock()
 	calls = mock.calls.SendInfo
@@ -165,24 +199,64 @@ func (mock *ClienterMock) SendInfoCalls() []struct {
 	return calls
 }
 
+// SendPublishLog calls SendPublishLogFunc.
+func (mock *ClienterMock) SendPublishLog(ctx context.Context, summary string, fields []slack.Field) (*slack.MessageRef, error) {
+	if mock.SendPublishLogFunc == nil {
+		panic("ClienterMock.SendPublishLogFunc: method is nil but Clienter.SendPublishLog was just called")
+	}
+	callInfo := struct {
+		Ctx     context.Context
+		Summary string
+		Fields  []slack.Field
+	}{
+		Ctx:     ctx,
+		Summary: summary,
+		Fields:  fields,
+	}
+	mock.lockSendPublishLog.Lock()
+	mock.calls.SendPublishLog = append(mock.calls.SendPublishLog, callInfo)
+	mock.lockSendPublishLog.Unlock()
+	return mock.SendPublishLogFunc(ctx, summary, fields)
+}
+
+// SendPublishLogCalls gets all the calls that were made to SendPublishLog.
+// Check the length with:
+//
+//	len(mockedClienter.SendPublishLogCalls())
+func (mock *ClienterMock) SendPublishLogCalls() []struct {
+	Ctx     context.Context
+	Summary string
+	Fields  []slack.Field
+} {
+	var calls []struct {
+		Ctx     context.Context
+		Summary string
+		Fields  []slack.Field
+	}
+	mock.lockSendPublishLog.RLock()
+	calls = mock.calls.SendPublishLog
+	mock.lockSendPublishLog.RUnlock()
+	return calls
+}
+
 // SendWarning calls SendWarningFunc.
-func (mock *ClienterMock) SendWarning(ctx context.Context, summary string, details map[string]interface{}) error {
+func (mock *ClienterMock) SendWarning(ctx context.Context, summary string, fields []slack.Field) (*slack.MessageRef, error) {
 	if mock.SendWarningFunc == nil {
 		panic("ClienterMock.SendWarningFunc: method is nil but Clienter.SendWarning was just called")
 	}
 	callInfo := struct {
 		Ctx     context.Context
 		Summary string
-		Details map[string]interface{}
+		Fields  []slack.Field
 	}{
 		Ctx:     ctx,
 		Summary: summary,
-		Details: details,
+		Fields:  fields,
 	}
 	mock.lockSendWarning.Lock()
 	mock.calls.SendWarning = append(mock.calls.SendWarning, callInfo)
 	mock.lockSendWarning.Unlock()
-	return mock.SendWarningFunc(ctx, summary, details)
+	return mock.SendWarningFunc(ctx, summary, fields)
 }
 
 // SendWarningCalls gets all the calls that were made to SendWarning.
@@ -192,15 +266,59 @@ func (mock *ClienterMock) SendWarning(ctx context.Context, summary string, detai
 func (mock *ClienterMock) SendWarningCalls() []struct {
 	Ctx     context.Context
 	Summary string
-	Details map[string]interface{}
+	Fields  []slack.Field
 } {
 	var calls []struct {
 		Ctx     context.Context
 		Summary string
-		Details map[string]interface{}
+		Fields  []slack.Field
 	}
 	mock.lockSendWarning.RLock()
 	calls = mock.calls.SendWarning
 	mock.lockSendWarning.RUnlock()
+	return calls
+}
+
+// UpdatePublishLog calls UpdatePublishLogFunc.
+func (mock *ClienterMock) UpdatePublishLog(ctx context.Context, ref *slack.MessageRef, summary string, fields []slack.Field) (*slack.MessageRef, error) {
+	if mock.UpdatePublishLogFunc == nil {
+		panic("ClienterMock.UpdatePublishLogFunc: method is nil but Clienter.UpdatePublishLog was just called")
+	}
+	callInfo := struct {
+		Ctx     context.Context
+		Ref     *slack.MessageRef
+		Summary string
+		Fields  []slack.Field
+	}{
+		Ctx:     ctx,
+		Ref:     ref,
+		Summary: summary,
+		Fields:  fields,
+	}
+	mock.lockUpdatePublishLog.Lock()
+	mock.calls.UpdatePublishLog = append(mock.calls.UpdatePublishLog, callInfo)
+	mock.lockUpdatePublishLog.Unlock()
+	return mock.UpdatePublishLogFunc(ctx, ref, summary, fields)
+}
+
+// UpdatePublishLogCalls gets all the calls that were made to UpdatePublishLog.
+// Check the length with:
+//
+//	len(mockedClienter.UpdatePublishLogCalls())
+func (mock *ClienterMock) UpdatePublishLogCalls() []struct {
+	Ctx     context.Context
+	Ref     *slack.MessageRef
+	Summary string
+	Fields  []slack.Field
+} {
+	var calls []struct {
+		Ctx     context.Context
+		Ref     *slack.MessageRef
+		Summary string
+		Fields  []slack.Field
+	}
+	mock.lockUpdatePublishLog.RLock()
+	calls = mock.calls.UpdatePublishLog
+	mock.lockUpdatePublishLog.RUnlock()
 	return calls
 }

--- a/slack/models.go
+++ b/slack/models.go
@@ -5,6 +5,8 @@ const (
 	InfoEmoji    Emoji = ":information_source:"
 	WarningEmoji Emoji = ":warning:"
 	AlarmEmoji   Emoji = ":rotating_light:"
+	TimerEmoji   Emoji = ":hourglass_flowing_sand:"
+	TickEmoji    Emoji = ":white_check_mark:"
 )
 
 type Emoji string
@@ -24,4 +26,17 @@ type Colour string
 
 func (c Colour) String() string {
 	return string(c)
+}
+
+// MessageRef represents a reference to a Slack message.
+// It contains the channel ID and timestamp of the message, which can be used for updating the message later.
+type MessageRef struct {
+	ChannelID string
+	Timestamp string
+}
+
+// Field represents a key-value pair to be included in the Slack message attachments.
+type Field struct {
+	Title string
+	Value string
 }

--- a/slack/noop_client.go
+++ b/slack/noop_client.go
@@ -5,14 +5,22 @@ import "context"
 // NoopClient is a Client that does nothing, used when Slack notifications are disabled
 type NoopClient struct{}
 
-func (n *NoopClient) SendAlarm(ctx context.Context, summary string, err error, details map[string]interface{}) error {
-	return nil
+func (n *NoopClient) SendAlarm(ctx context.Context, summary string, err error, fields []Field) (*MessageRef, error) {
+	return nil, nil
 }
 
-func (n *NoopClient) SendWarning(ctx context.Context, summary string, details map[string]interface{}) error {
-	return nil
+func (n *NoopClient) SendWarning(ctx context.Context, summary string, fields []Field) (*MessageRef, error) {
+	return nil, nil
 }
 
-func (n *NoopClient) SendInfo(ctx context.Context, summary string, details map[string]interface{}) error {
-	return nil
+func (n *NoopClient) SendInfo(ctx context.Context, summary string, fields []Field) (*MessageRef, error) {
+	return nil, nil
+}
+
+func (n *NoopClient) SendPublishLog(ctx context.Context, summary string, fields []Field) (*MessageRef, error) {
+	return nil, nil
+}
+
+func (n *NoopClient) UpdatePublishLog(ctx context.Context, ref *MessageRef, summary string, fields []Field) (*MessageRef, error) {
+	return nil, nil
 }

--- a/slack/noop_client_test.go
+++ b/slack/noop_client_test.go
@@ -14,10 +14,11 @@ func TestNoopClient_SendError(t *testing.T) {
 		client := &slack.NoopClient{}
 
 		Convey("When SendAlarm is called", func() {
-			err := client.SendAlarm(context.Background(), "Test Summary", errors.New("Test Error"), nil)
+			ref, err := client.SendAlarm(context.Background(), "Test Summary", errors.New("Test Error"), nil)
 
 			Convey("Then no error is returned", func() {
 				So(err, ShouldBeNil)
+				So(ref, ShouldBeNil)
 			})
 		})
 	})
@@ -28,10 +29,11 @@ func TestNoopClient_SendWarning(t *testing.T) {
 		client := &slack.NoopClient{}
 
 		Convey("When SendWarning is called", func() {
-			err := client.SendWarning(context.Background(), "Test Summary", nil)
+			ref, err := client.SendWarning(context.Background(), "Test Summary", nil)
 
 			Convey("Then no error is returned", func() {
 				So(err, ShouldBeNil)
+				So(ref, ShouldBeNil)
 			})
 		})
 	})
@@ -42,10 +44,41 @@ func TestNoopClient_SendInfo(t *testing.T) {
 		client := &slack.NoopClient{}
 
 		Convey("When SendInfo is called", func() {
-			err := client.SendInfo(context.Background(), "Test Summary", nil)
+			ref, err := client.SendInfo(context.Background(), "Test Summary", nil)
 
 			Convey("Then no error is returned", func() {
 				So(err, ShouldBeNil)
+				So(ref, ShouldBeNil)
+			})
+		})
+	})
+}
+
+func TestNoopClient_SendPublishLog(t *testing.T) {
+	Convey("Given a NoopClient", t, func() {
+		client := &slack.NoopClient{}
+
+		Convey("When SendPublishLog is called", func() {
+			ref, err := client.SendPublishLog(context.Background(), "Test Summary", nil)
+
+			Convey("Then no error is returned", func() {
+				So(err, ShouldBeNil)
+				So(ref, ShouldBeNil)
+			})
+		})
+	})
+}
+
+func TestNoopClient_UpdatePublishLog(t *testing.T) {
+	Convey("Given a NoopClient", t, func() {
+		client := &slack.NoopClient{}
+
+		Convey("When UpdatePublishLog is called", func() {
+			ref, err := client.UpdatePublishLog(context.Background(), &slack.MessageRef{ChannelID: "test-channel", Timestamp: "1234567890.123456"}, "Test Summary", nil)
+
+			Convey("Then no error is returned", func() {
+				So(err, ShouldBeNil)
+				So(ref, ShouldBeNil)
 			})
 		})
 	})

--- a/store/datastore.go
+++ b/store/datastore.go
@@ -32,6 +32,7 @@ type dataMongoDB interface {
 	GetBundlesByPreviewTeamID(ctx context.Context, teamID string) ([]*models.Bundle, error)
 
 	// Content items
+	CountBundleContents(ctx context.Context, bundleID string) (int, error)
 	ListBundleContents(ctx context.Context, bundleID string, offset, limit int) ([]*models.ContentItem, int, error)
 	ListBundleContentIDsWithoutLimit(ctx context.Context, bundleID string) (contents []*models.ContentItem, err error)
 	GetContentItemByBundleIDAndContentItemID(ctx context.Context, bundleID, contentItemID string) (*models.ContentItem, error)

--- a/store/datastoretest/datastore.go
+++ b/store/datastoretest/datastore.go
@@ -44,6 +44,9 @@ var _ store.Storer = &StorerMock{}
 //			CloseFunc: func(ctx context.Context) error {
 //				panic("mock out the Close method")
 //			},
+//			CountBundleContentsFunc: func(ctx context.Context, bundleID string) (int, error) {
+//				panic("mock out the CountBundleContents method")
+//			},
 //			CreateBundleFunc: func(ctx context.Context, bundle *models.Bundle) error {
 //				panic("mock out the CreateBundle method")
 //			},
@@ -125,6 +128,9 @@ type StorerMock struct {
 
 	// CloseFunc mocks the Close method.
 	CloseFunc func(ctx context.Context) error
+
+	// CountBundleContentsFunc mocks the CountBundleContents method.
+	CountBundleContentsFunc func(ctx context.Context, bundleID string) (int, error)
 
 	// CreateBundleFunc mocks the CreateBundle method.
 	CreateBundleFunc func(ctx context.Context, bundle *models.Bundle) error
@@ -234,6 +240,13 @@ type StorerMock struct {
 		Close []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
+		}
+		// CountBundleContents holds details about calls to the CountBundleContents method.
+		CountBundleContents []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// BundleID is the bundleID argument value.
+			BundleID string
 		}
 		// CreateBundle holds details about calls to the CreateBundle method.
 		CreateBundle []struct {
@@ -397,6 +410,7 @@ type StorerMock struct {
 	lockCheckContentItemExistsByDatasetEditionVersion sync.RWMutex
 	lockChecker                                       sync.RWMutex
 	lockClose                                         sync.RWMutex
+	lockCountBundleContents                           sync.RWMutex
 	lockCreateBundle                                  sync.RWMutex
 	lockCreateContentItem                             sync.RWMutex
 	lockCreateEvent                                   sync.RWMutex
@@ -674,6 +688,42 @@ func (mock *StorerMock) CloseCalls() []struct {
 	mock.lockClose.RLock()
 	calls = mock.calls.Close
 	mock.lockClose.RUnlock()
+	return calls
+}
+
+// CountBundleContents calls CountBundleContentsFunc.
+func (mock *StorerMock) CountBundleContents(ctx context.Context, bundleID string) (int, error) {
+	if mock.CountBundleContentsFunc == nil {
+		panic("StorerMock.CountBundleContentsFunc: method is nil but Storer.CountBundleContents was just called")
+	}
+	callInfo := struct {
+		Ctx      context.Context
+		BundleID string
+	}{
+		Ctx:      ctx,
+		BundleID: bundleID,
+	}
+	mock.lockCountBundleContents.Lock()
+	mock.calls.CountBundleContents = append(mock.calls.CountBundleContents, callInfo)
+	mock.lockCountBundleContents.Unlock()
+	return mock.CountBundleContentsFunc(ctx, bundleID)
+}
+
+// CountBundleContentsCalls gets all the calls that were made to CountBundleContents.
+// Check the length with:
+//
+//	len(mockedStorer.CountBundleContentsCalls())
+func (mock *StorerMock) CountBundleContentsCalls() []struct {
+	Ctx      context.Context
+	BundleID string
+} {
+	var calls []struct {
+		Ctx      context.Context
+		BundleID string
+	}
+	mock.lockCountBundleContents.RLock()
+	calls = mock.calls.CountBundleContents
+	mock.lockCountBundleContents.RUnlock()
 	return calls
 }
 

--- a/store/datastoretest/mongo.go
+++ b/store/datastoretest/mongo.go
@@ -44,6 +44,9 @@ var _ store.MongoDB = &MongoDBMock{}
 //			CloseFunc: func(contextMoqParam context.Context) error {
 //				panic("mock out the Close method")
 //			},
+//			CountBundleContentsFunc: func(ctx context.Context, bundleID string) (int, error) {
+//				panic("mock out the CountBundleContents method")
+//			},
 //			CreateBundleFunc: func(ctx context.Context, bundle *models.Bundle) error {
 //				panic("mock out the CreateBundle method")
 //			},
@@ -125,6 +128,9 @@ type MongoDBMock struct {
 
 	// CloseFunc mocks the Close method.
 	CloseFunc func(contextMoqParam context.Context) error
+
+	// CountBundleContentsFunc mocks the CountBundleContents method.
+	CountBundleContentsFunc func(ctx context.Context, bundleID string) (int, error)
 
 	// CreateBundleFunc mocks the CreateBundle method.
 	CreateBundleFunc func(ctx context.Context, bundle *models.Bundle) error
@@ -234,6 +240,13 @@ type MongoDBMock struct {
 		Close []struct {
 			// ContextMoqParam is the contextMoqParam argument value.
 			ContextMoqParam context.Context
+		}
+		// CountBundleContents holds details about calls to the CountBundleContents method.
+		CountBundleContents []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// BundleID is the bundleID argument value.
+			BundleID string
 		}
 		// CreateBundle holds details about calls to the CreateBundle method.
 		CreateBundle []struct {
@@ -397,6 +410,7 @@ type MongoDBMock struct {
 	lockCheckContentItemExistsByDatasetEditionVersion sync.RWMutex
 	lockChecker                                       sync.RWMutex
 	lockClose                                         sync.RWMutex
+	lockCountBundleContents                           sync.RWMutex
 	lockCreateBundle                                  sync.RWMutex
 	lockCreateContentItem                             sync.RWMutex
 	lockCreateEvent                                   sync.RWMutex
@@ -674,6 +688,42 @@ func (mock *MongoDBMock) CloseCalls() []struct {
 	mock.lockClose.RLock()
 	calls = mock.calls.Close
 	mock.lockClose.RUnlock()
+	return calls
+}
+
+// CountBundleContents calls CountBundleContentsFunc.
+func (mock *MongoDBMock) CountBundleContents(ctx context.Context, bundleID string) (int, error) {
+	if mock.CountBundleContentsFunc == nil {
+		panic("MongoDBMock.CountBundleContentsFunc: method is nil but MongoDB.CountBundleContents was just called")
+	}
+	callInfo := struct {
+		Ctx      context.Context
+		BundleID string
+	}{
+		Ctx:      ctx,
+		BundleID: bundleID,
+	}
+	mock.lockCountBundleContents.Lock()
+	mock.calls.CountBundleContents = append(mock.calls.CountBundleContents, callInfo)
+	mock.lockCountBundleContents.Unlock()
+	return mock.CountBundleContentsFunc(ctx, bundleID)
+}
+
+// CountBundleContentsCalls gets all the calls that were made to CountBundleContents.
+// Check the length with:
+//
+//	len(mockedMongoDB.CountBundleContentsCalls())
+func (mock *MongoDBMock) CountBundleContentsCalls() []struct {
+	Ctx      context.Context
+	BundleID string
+} {
+	var calls []struct {
+		Ctx      context.Context
+		BundleID string
+	}
+	mock.lockCountBundleContents.RLock()
+	calls = mock.calls.CountBundleContents
+	mock.lockCountBundleContents.RUnlock()
 	return calls
 }
 

--- a/utils/time.go
+++ b/utils/time.go
@@ -1,0 +1,6 @@
+package utils
+
+const (
+	// SlackPublishTimeFormat defines how time should be formatted in Slack messages for publish logs
+	SlackPublishTimeFormat = "Mon 02 Jan 2006 at 15:04:05.0000"
+)


### PR DESCRIPTION
### What

Ticket: https://officefornationalstatistics.atlassian.net/browse/DIS-4710

- Use pinned tags in CI
- Send slack notification to publish-log when bundle is moving to published. This same message will then be edited to add the end date and duration of the publication
- Updated the slack package so it can return a message reference, update existing messages and format fields into two columns in the same order as they are set. (Previously they could appear in any order due to details being a map)

**Notes:**
- The slack package is only being used by this service so the function definition changes will not cause issues elsewhere.
- Any failures that happen while sending slack notifications will not stop publication from happening. This includes getting the content item count which will only be logged if it fails. This has been been commented explaining why in the code.
- The `application` package will show low unit test coverage but this is because it is tested by the API package. (This is the case for many of the state machine functions and will likely remain this way until enter function tech debt tickets are picked up)

### How to review

- Run the dataset-catalogue stack with all slack env vars set (to sandbox values)
- Publish a bundle and ensure a notification has been sent and edited in the sandbox publish log channel.
- (To make testing easier you can manually add a `time.Sleep()` line before the message gets edited in order to see the initial message)

### Who can review

- Anyone
