### PR TITLE
Feature/content item publish

### DIFF
--- a/application/application.go
+++ b/application/application.go
@@ -213,12 +213,6 @@ func (s *StateMachineBundleAPI) updateVersionStateForContentItem(ctx context.Con
 		return err
 	}
 
-	log.Info(ctx, "version state check", log.Data{
-		"version_state": version.State,
-		"target_state":  targetState.String(),
-		"dataset_id":    contentItem.Metadata.DatasetID,
-	})
-
 	// TODO: remove this if condition once we know if approved or published versions can be added to bundles
 	// If the version state is the same as the target state or if it is already published then do not update the version state
 	if strings.EqualFold(version.State, targetState.String()) || strings.EqualFold(version.State, models.StatePublished.String()) {

--- a/application/application.go
+++ b/application/application.go
@@ -213,6 +213,12 @@ func (s *StateMachineBundleAPI) updateVersionStateForContentItem(ctx context.Con
 		return err
 	}
 
+	log.Info(ctx, "version state check", log.Data{
+		"version_state": version.State,
+		"target_state":  targetState.String(),
+		"dataset_id":    contentItem.Metadata.DatasetID,
+	})
+
 	// TODO: remove this if condition once we know if approved or published versions can be added to bundles
 	// If the version state is the same as the target state or if it is already published then do not update the version state
 	if strings.EqualFold(version.State, targetState.String()) || strings.EqualFold(version.State, models.StatePublished.String()) {

--- a/application/state_machine.go
+++ b/application/state_machine.go
@@ -160,7 +160,7 @@ func (sm *StateMachine) TransitionBundle(ctx context.Context, stateMachineBundle
 			err = sm.transitionContentItem(ctx, contentItem, stateMachineBundleAPI, targetState, authEntityData)
 			if err != nil {
 				log.Warn(ctx, fmt.Sprintf("Error occurred transitioning content item for bundle: %s", err.Error()), log.Data{"bundle-id": bundle.ID, "content-item-id": contentItem.ID})
-				return nil, err
+				continue
 			}
 		}
 	}

--- a/application/state_machine_test.go
+++ b/application/state_machine_test.go
@@ -877,4 +877,64 @@ func TestTransitionBundle_Failure(t *testing.T) {
 			})
 		})
 	})
+
+	t.Run("When one content item fails to transition, the remaining content items should still be processed", func(t *testing.T) {
+		mockBundle.State = fromState
+		createdEvents = nil
+
+		for index := range mockVersions {
+			mockVersions[index].State = strings.ToLower(fromState.String())
+		}
+		for index := range mockContentItems {
+			state := models.State(fromState.String())
+			mockContentItems[index].State = &state
+		}
+
+		mockedDatastore.GetBundleContentsForBundleFunc = getBundleContentsFunc
+		mockedDatastore.UpdateBundleFunc = updateBundleFunc
+		mockedDatastore.CreateEventFunc = createEventFunc
+		mockedDatastore.UpdateContentItemStateFunc = updateContentItemFunc
+
+		mockdatasetAPIClient.PutVersionStateFunc = func(ctx context.Context, headers datasetAPISDK.Headers, datasetID, editionID, versionID, state string) error {
+			if datasetID == mockVersions[0].DatasetID {
+				return errors.New("failed to update version state")
+			}
+			version, err := getVersionFunc(ctx, headers, datasetID, editionID, versionID)
+			if err != nil {
+				return err
+			}
+			version.State = state
+			return nil
+		}
+
+		stateMachine := NewStateMachine(ctx, states, transitions, store.Datastore{Backend: mockedDatastore})
+		stateMachineBundleAPI := Setup(store.Datastore{Backend: mockedDatastore}, stateMachine, &mockdatasetAPIClient, mockPermissionsAPIClient, mockSlackClient)
+
+		bundleInstance := *mockBundle
+		bundle, err := stateMachine.TransitionBundle(ctx, stateMachineBundleAPI, &bundleInstance, &targetState, &mockAuthEntityData)
+
+		Convey("Then no error should be returned", t, func() {
+			So(err, ShouldBeNil)
+
+			Convey("And the bundle should be returned", func() {
+				So(bundle, ShouldNotBeNil)
+			})
+
+			Convey("And the bundle state should be updated to published", func() {
+				So(mockBundle.State.String(), ShouldEqual, targetState.String())
+			})
+
+			Convey("And events should only be created for the successful content item and the bundle", func() {
+				So(createdEvents, ShouldHaveLength, 2)
+			})
+
+			Convey("And the second content item state should be updated", func() {
+				So(mockContentItems[1].State.String(), ShouldEqual, targetState.String())
+			})
+
+			Convey("And the first content item state should not be updated", func() {
+				So(mockContentItems[0].State.String(), ShouldNotEqual, targetState.String())
+			})
+		})
+	})
 }

--- a/features/bundles_put_state.feature
+++ b/features/bundles_put_state.feature
@@ -144,6 +144,22 @@ Feature: Update Bundles functionality - PUT /bundles/{id}/state
                     "title": "bundle-10",
                     "updated_at": "2025-04-05T13:40:00Z",
                     "managed_by": "WAGTAIL"
+                },
+                {
+                    "id": "bundle-11",
+                    "bundle_type": "MANUAL",
+                    "created_by": {
+                        "email": "publisher@ons.gov.uk"
+                    },
+                    "created_at": "2025-04-05T13:40:00Z",
+                    "last_updated_by": {
+                        "email": "publisher@ons.gov.uk"
+                    },
+                    "preview_teams": [],
+                    "state": "APPROVED",
+                    "title": "bundle-11",
+                    "updated_at": "2025-04-05T13:40:00Z",
+                    "managed_by": "WAGTAIL"
                 }
             ]
             """
@@ -295,6 +311,38 @@ Feature: Update Bundles functionality - PUT /bundles/{id}/state
                         "edition_id": "edition10",
                         "version_id": 7,
                         "title": "Test Dataset 11"
+                    },
+                    "links": {
+                        "edit": "edit/link",
+                        "preview": "preview/link"
+                    },
+                    "state": "APPROVED"
+                },
+                {
+                    "id": "content-item-19",
+                    "bundle_id": "bundle-11",
+                    "content_type": "DATASET",
+                    "metadata": {
+                        "dataset_id": "dataset4",
+                        "edition_id": "edition4",
+                        "version_id": 1,
+                        "title": "Test Dataset 4"
+                    },
+                    "links": {
+                        "edit": "edit/link",
+                        "preview": "preview/link"
+                    },
+                    "state": "APPROVED"
+                },
+                {
+                    "id": "content-item-20",
+                    "bundle_id": "bundle-11",
+                    "content_type": "DATASET",
+                    "metadata": {
+                        "dataset_id": "dataset-missing",
+                        "edition_id": "edition-missing",
+                        "version_id": 11,
+                        "title": "Missing Dataset"
                     },
                     "links": {
                         "edit": "edit/link",
@@ -615,10 +663,38 @@ Feature: Update Bundles functionality - PUT /bundles/{id}/state
                     "state": "APPROVED"
                 }
             """
-        Then the HTTP status code should be "500"
-        And bundle "bundle-10" should have state "IN_REVIEW"
-        And bundle "bundle-10" should have this etag "etag-bundle-10"
+        Then the HTTP status code should be "200"
+        And bundle "bundle-10" should have state "APPROVED"
+        And bundle "bundle-10" should not have this etag "etag-bundle-10"
 
+    Scenario: PUT /bundles/{id}/state where one content item fails but the remaining content item is still processed
+        Given I am an admin user
+        And I set the "If-Match" header to "etag-bundle-11"
+        When I PUT "/bundles/bundle-11/state"
+            """
+                {
+                    "state": "PUBLISHED"
+                }
+            """
+        Then the HTTP status code should be "200"
+        And bundle "bundle-11" should have state "PUBLISHED"
+        And bundle "bundle-11" should not have this etag "etag-bundle-11"
+        And these content item states should match:
+            """
+            [
+                {
+                    "id": "content-item-19",
+                    "state": "PUBLISHED"
+                },
+                {
+                    "id": "content-item-20",
+                    "state": "APPROVED"
+                }
+            ]
+            """
+        And the total number of events should be 2
+        And the number of events with action "UPDATE" and datatype "bundle" should be 1
+        And the number of events with action "UPDATE" and datatype "content_item" should be 1
 
     Scenario: PUT /bundles/{id}/state with valid arguments for 'IN_REVIEW' -> 'APPROVED'
         Given I am an admin user

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/ONSdigital/dp-api-clients-go/v2 v2.274.2
 	github.com/ONSdigital/dp-authorisation/v2 v2.34.0
 	github.com/ONSdigital/dp-component-test v1.2.6-alpha
-	github.com/ONSdigital/dp-dataset-api v1.101.1
+	github.com/ONSdigital/dp-dataset-api v1.104.0
 	github.com/ONSdigital/dp-healthcheck v1.6.4
 	github.com/ONSdigital/dp-mongodb/v3 v3.12.0
 	github.com/ONSdigital/dp-net/v3 v3.10.0

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,8 @@ github.com/ONSdigital/dp-authorisation/v2 v2.34.0 h1:Zc096gAh5S7PFG1LlbM/siZDvyz
 github.com/ONSdigital/dp-authorisation/v2 v2.34.0/go.mod h1:y3zXIX/x8baEKucG05v/PL86GtL7MAz9Eb3HcwZmuvQ=
 github.com/ONSdigital/dp-component-test v1.2.6-alpha h1:gPwu2xayWxdM0hmJvDX2/9UC8iStMrWKLB7aro6OhSc=
 github.com/ONSdigital/dp-component-test v1.2.6-alpha/go.mod h1:5IYvqiKqKTfkN5lTbIH8NzUxjclsztWgEroKxY/MVEE=
-github.com/ONSdigital/dp-dataset-api v1.101.1 h1:eZeYKe5mGYpp9ZsQhrQtxKA4MeWqcmwJhkiRibzBDOE=
-github.com/ONSdigital/dp-dataset-api v1.101.1/go.mod h1:eZHG04MFaPEnSTLjdzqUMioryrO/SkSI2nNgvg7RMa8=
+github.com/ONSdigital/dp-dataset-api v1.104.0 h1:gwrih7hGLx0hc68mp+YCFl4yMUCtxH0qYeX3Eamu6Gc=
+github.com/ONSdigital/dp-dataset-api v1.104.0/go.mod h1:iy7ixBHTtgmzF65tgq+9SJwNefyetVCWuazoaKoaoJI=
 github.com/ONSdigital/dp-healthcheck v1.6.4 h1:FhWOuVmob36dYq7AzCdbgyf0Vk58IFitSl8y8pWJ8ck=
 github.com/ONSdigital/dp-healthcheck v1.6.4/go.mod h1:j3UNbGT4ZJg1chrRkPLE6YUVYCg1su3AAQ8frcBrvgc=
 github.com/ONSdigital/dp-mocking v0.11.0 h1:laln6e2JD4vtsYbg0cTw9ur1Xf390AUYdd85cG2UNQw=


### PR DESCRIPTION
### What

Update to allow remaining content items in bundle to be processed even if one fails
Jira - https://officefornationalstatistics.atlassian.net/browse/DIS-4761

### How to review

To test locally - 

- create two datasets each with an edition and version 
- set one version to `approved` state and leave the other as `associated` 
- register file metadata for both datasets via dp-files-api and patch them to `UPLOADED` state 
- create a bundle, add both datasets as content items then move the bundle through the states to `APPROVED` 
- publish the bundle and check the bundle api logs, you should see the associated version fail with "Version state is not approved" but the loop should continue, with the bundle transitioning to `PUBLISHED` and returning a 200

### Who can review

Anyone
