### PR TITLE
add slack notification for failed content items

### DIFF
--- a/api/bundle_events_test.go
+++ b/api/bundle_events_test.go
@@ -35,7 +35,7 @@ func TestGetBundleEvents_Success(t *testing.T) {
 		mockPermissionsAPIClient := &permissionsAPISDKMock.ClienterMock{}
 		mockSlackClient := &slackMock.ClienterMock{}
 		stateMachine := &application.StateMachine{}
-		stateMachineBundleAPI := application.Setup(store.Datastore{Backend: mockDatastore}, stateMachine, mockDatasetAPIClient, mockPermissionsAPIClient, mockSlackClient)
+		stateMachineBundleAPI := application.Setup(store.Datastore{Backend: mockDatastore}, stateMachine, mockDatasetAPIClient, mockPermissionsAPIClient, mockSlackClient, "")
 
 		api := &BundleAPI{
 			stateMachineBundleAPI: stateMachineBundleAPI,
@@ -69,7 +69,7 @@ func TestGetBundleEvents_WithBundleFilter(t *testing.T) {
 		mockPermissionsAPIClient := &permissionsAPISDKMock.ClienterMock{}
 		mockSlackClient := &slackMock.ClienterMock{}
 		stateMachine := &application.StateMachine{}
-		stateMachineBundleAPI := application.Setup(store.Datastore{Backend: mockDatastore}, stateMachine, mockDatasetAPIClient, mockPermissionsAPIClient, mockSlackClient)
+		stateMachineBundleAPI := application.Setup(store.Datastore{Backend: mockDatastore}, stateMachine, mockDatasetAPIClient, mockPermissionsAPIClient, mockSlackClient, "")
 
 		api := &BundleAPI{
 			stateMachineBundleAPI: stateMachineBundleAPI,
@@ -110,7 +110,7 @@ func TestGetBundleEvents_WithDateFilter(t *testing.T) {
 		mockPermissionsAPIClient := &permissionsAPISDKMock.ClienterMock{}
 		mockSlackClient := &slackMock.ClienterMock{}
 		stateMachine := &application.StateMachine{}
-		stateMachineBundleAPI := application.Setup(store.Datastore{Backend: mockDatastore}, stateMachine, mockDatasetAPIClient, mockPermissionsAPIClient, mockSlackClient)
+		stateMachineBundleAPI := application.Setup(store.Datastore{Backend: mockDatastore}, stateMachine, mockDatasetAPIClient, mockPermissionsAPIClient, mockSlackClient, "")
 
 		api := &BundleAPI{
 			stateMachineBundleAPI: stateMachineBundleAPI,
@@ -138,7 +138,7 @@ func TestGetBundleEvents_InvalidDateFormat(t *testing.T) {
 		mockDatasetAPIClient := &datasetAPISDKMock.ClienterMock{}
 		mockPermissionsAPIClient := &permissionsAPISDKMock.ClienterMock{}
 		mockSlackClient := &slackMock.ClienterMock{}
-		stateMachineBundleAPI := application.Setup(store.Datastore{Backend: mockDatastore}, stateMachine, mockDatasetAPIClient, mockPermissionsAPIClient, mockSlackClient)
+		stateMachineBundleAPI := application.Setup(store.Datastore{Backend: mockDatastore}, stateMachine, mockDatasetAPIClient, mockPermissionsAPIClient, mockSlackClient, "")
 
 		api := &BundleAPI{
 			stateMachineBundleAPI: stateMachineBundleAPI,
@@ -166,7 +166,7 @@ func TestGetBundleEvents_UnknownParameter(t *testing.T) {
 		mockPermissionsAPIClient := &permissionsAPISDKMock.ClienterMock{}
 		mockSlackClient := &slackMock.ClienterMock{}
 		stateMachine := &application.StateMachine{}
-		stateMachineBundleAPI := application.Setup(store.Datastore{Backend: mockDatastore}, stateMachine, mockDatasetAPIClient, mockPermissionsAPIClient, mockSlackClient)
+		stateMachineBundleAPI := application.Setup(store.Datastore{Backend: mockDatastore}, stateMachine, mockDatasetAPIClient, mockPermissionsAPIClient, mockSlackClient, "")
 
 		api := &BundleAPI{
 			stateMachineBundleAPI: stateMachineBundleAPI,
@@ -199,7 +199,7 @@ func TestGetBundleEvents_InternalError(t *testing.T) {
 		mockPermissionsAPIClient := &permissionsAPISDKMock.ClienterMock{}
 		mockSlackClient := &slackMock.ClienterMock{}
 		stateMachine := &application.StateMachine{}
-		stateMachineBundleAPI := application.Setup(store.Datastore{Backend: mockDatastore}, stateMachine, mockDatasetAPIClient, mockPermissionsAPIClient, mockSlackClient)
+		stateMachineBundleAPI := application.Setup(store.Datastore{Backend: mockDatastore}, stateMachine, mockDatasetAPIClient, mockPermissionsAPIClient, mockSlackClient, "")
 
 		api := &BundleAPI{
 			stateMachineBundleAPI: stateMachineBundleAPI,
@@ -233,7 +233,7 @@ func TestGetBundleEvents_NoResults(t *testing.T) {
 		mockPermissionsAPIClient := &permissionsAPISDKMock.ClienterMock{}
 		mockSlackClient := &slackMock.ClienterMock{}
 		stateMachine := &application.StateMachine{}
-		stateMachineBundleAPI := application.Setup(store.Datastore{Backend: mockDatastore}, stateMachine, mockDatasetAPIClient, mockPermissionsAPIClient, mockSlackClient)
+		stateMachineBundleAPI := application.Setup(store.Datastore{Backend: mockDatastore}, stateMachine, mockDatasetAPIClient, mockPermissionsAPIClient, mockSlackClient, "")
 
 		api := &BundleAPI{
 			stateMachineBundleAPI: stateMachineBundleAPI,

--- a/application/application.go
+++ b/application/application.go
@@ -28,15 +28,17 @@ type StateMachineBundleAPI struct {
 	DatasetAPIClient      datasetAPISDK.Clienter
 	PermissionsAPIClient  permissionsAPISDK.Clienter
 	DataBundleSlackClient slack.Clienter
+	PreviewServiceURL     string
 }
 
-func Setup(datastore store.Datastore, stateMachine *StateMachine, datasetAPIClient datasetAPISDK.Clienter, permissionsAPIClient permissionsAPISDK.Clienter, dataBundleSlackClient slack.Clienter) *StateMachineBundleAPI {
+func Setup(datastore store.Datastore, stateMachine *StateMachine, datasetAPIClient datasetAPISDK.Clienter, permissionsAPIClient permissionsAPISDK.Clienter, dataBundleSlackClient slack.Clienter, previewServiceURL string) *StateMachineBundleAPI {
 	return &StateMachineBundleAPI{
 		Datastore:             datastore,
 		StateMachine:          stateMachine,
 		DatasetAPIClient:      datasetAPIClient,
 		PermissionsAPIClient:  permissionsAPIClient,
 		DataBundleSlackClient: dataBundleSlackClient,
+		PreviewServiceURL:     previewServiceURL,
 	}
 }
 
@@ -176,7 +178,7 @@ func (s *StateMachineBundleAPI) UpdateBundleState(ctx context.Context, bundleID,
 		}
 	}
 
-	updatedBundle, err := s.StateMachine.TransitionBundle(ctx, s, bundle, &targetState, authEntityData)
+	updatedBundle, hadContentItemFailures, err := s.StateMachine.TransitionBundle(ctx, s, bundle, &targetState, authEntityData)
 	if err != nil {
 		if isPublishTransition {
 			_, err := s.DataBundleSlackClient.SendAlarm(ctx, "Failed to publish bundle", err, publishLogFields)
@@ -195,10 +197,18 @@ func (s *StateMachineBundleAPI) UpdateBundleState(ctx context.Context, bundleID,
 		)
 		logData["slack_fields"] = publishLogFields
 
-		log.Info(ctx, "updating slack notification: Bundle publish completed", logData)
-		_, err := s.DataBundleSlackClient.UpdatePublishLog(ctx, slackMessageRef, "Bundle publish completed", publishLogFields)
-		if err != nil {
-			log.Error(ctx, "failed to send slack notification: Bundle publish completed", err, logData)
+		if hadContentItemFailures {
+			log.Info(ctx, "updating slack notification: Bundle publish completed with errors", logData)
+			_, err = s.DataBundleSlackClient.UpdatePublishLogAsAlarm(ctx, slackMessageRef, "Bundle publish completed with errors", publishLogFields)
+			if err != nil {
+				log.Error(ctx, "failed to update slack notification: Bundle publish completed with errors", err, logData)
+			}
+		} else {
+			log.Info(ctx, "updating slack notification: Bundle publish completed", logData)
+			_, err = s.DataBundleSlackClient.UpdatePublishLog(ctx, slackMessageRef, "Bundle publish completed", publishLogFields)
+			if err != nil {
+				log.Error(ctx, "failed to send slack notification: Bundle publish completed", err, logData)
+			}
 		}
 	}
 

--- a/application/state_machine.go
+++ b/application/state_machine.go
@@ -5,9 +5,11 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"strconv"
 
 	"github.com/ONSdigital/dis-bundle-api/apierrors"
 	"github.com/ONSdigital/dis-bundle-api/models"
+	"github.com/ONSdigital/dis-bundle-api/slack"
 	"github.com/ONSdigital/dis-bundle-api/store"
 	"github.com/ONSdigital/log.go/v2/log"
 )
@@ -140,19 +142,21 @@ func (sm *StateMachine) IsValidTransition(ctx context.Context, sourceState, targ
 	return nil
 }
 
-func (sm *StateMachine) TransitionBundle(ctx context.Context, stateMachineBundleAPI *StateMachineBundleAPI, bundle *models.Bundle, targetState *models.BundleState, authEntityData *models.AuthEntityData) (*models.Bundle, error) {
+func (sm *StateMachine) TransitionBundle(ctx context.Context, stateMachineBundleAPI *StateMachineBundleAPI, bundle *models.Bundle, targetState *models.BundleState, authEntityData *models.AuthEntityData) (*models.Bundle, bool, error) {
 	if err := sm.IsValidTransition(ctx, &bundle.State, targetState); err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	contents, err := stateMachineBundleAPI.Datastore.GetBundleContentsForBundle(ctx, bundle.ID)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	if contents == nil || len(*contents) == 0 {
-		return nil, apierrors.ErrBundleHasNoContentItems
+		return nil, false, apierrors.ErrBundleHasNoContentItems
 	}
+
+	hadContentItemFailures := false
 
 	if targetState.String() == models.BundleStateApproved.String() || targetState.String() == models.BundleStatePublished.String() {
 		for index := range *contents {
@@ -160,6 +164,35 @@ func (sm *StateMachine) TransitionBundle(ctx context.Context, stateMachineBundle
 			err = sm.transitionContentItem(ctx, contentItem, stateMachineBundleAPI, targetState, authEntityData)
 			if err != nil {
 				log.Warn(ctx, fmt.Sprintf("Error occurred transitioning content item for bundle: %s", err.Error()), log.Data{"bundle-id": bundle.ID, "content-item-id": contentItem.ID})
+
+				previewURL := fmt.Sprintf("%s/datasets/%s/editions/%s/versions/%s",
+					stateMachineBundleAPI.PreviewServiceURL,
+					contentItem.Metadata.DatasetID,
+					contentItem.Metadata.EditionID,
+					strconv.Itoa(contentItem.Metadata.VersionID),
+				)
+
+				alarmFields := []slack.Field{
+					{Title: "Bundle ID", Value: bundle.ID},
+					{Title: "Bundle Title", Value: bundle.Title},
+					{Title: "Dataset ID", Value: contentItem.Metadata.DatasetID},
+					{Title: "Edition", Value: contentItem.Metadata.EditionID},
+					{Title: "Version", Value: strconv.Itoa(contentItem.Metadata.VersionID)},
+					{Title: "Preview Link", Value: previewURL},
+				}
+
+				_, alarmErr := stateMachineBundleAPI.DataBundleSlackClient.SendAlarm(ctx, "Bundle content item failed to publish", err, alarmFields)
+				if alarmErr != nil {
+					log.Error(ctx, "failed to send slack alarm for content item failure", alarmErr, log.Data{"bundle-id": bundle.ID, "content-item-id": contentItem.ID})
+				}
+
+				log.Info(ctx, "sending slack alarm for content item failure", log.Data{
+					"bundle-id":       bundle.ID,
+					"content-item-id": contentItem.ID,
+					"alarm_fields":    alarmFields,
+				})
+
+				hadContentItemFailures = true
 				continue
 			}
 		}
@@ -170,7 +203,7 @@ func (sm *StateMachine) TransitionBundle(ctx context.Context, stateMachineBundle
 
 	updatedBundle, err := stateMachineBundleAPI.Datastore.UpdateBundle(ctx, bundle.ID, bundle)
 	if err != nil {
-		return nil, err
+		return nil, hadContentItemFailures, err
 	}
 
 	identityType := log.USER
@@ -181,11 +214,11 @@ func (sm *StateMachine) TransitionBundle(ctx context.Context, stateMachineBundle
 
 	if err = stateMachineBundleAPI.CreateEvent(ctx, authEntityData, models.ActionUpdate, updatedBundle, nil); err != nil {
 		log.Error(ctx, "failed to create event", err, log.Classification(log.ProtectiveMonitoring), logAuth, log.Data{"bundle_id": updatedBundle.ID, "action": models.ActionUpdate})
-		return nil, err
+		return nil, hadContentItemFailures, err
 	}
 	log.Info(ctx, "bundle event creation successful", log.Classification(log.ProtectiveMonitoring), logAuth, log.Data{"bundle_id": updatedBundle.ID, "action": models.ActionUpdate})
 
-	return updatedBundle, nil
+	return updatedBundle, hadContentItemFailures, nil
 }
 
 func (*StateMachine) transitionContentItem(ctx context.Context, contentItem *models.ContentItem, stateMachineBundleAPI *StateMachineBundleAPI, targetState *models.BundleState, authEntityData *models.AuthEntityData) error {

--- a/application/state_machine_test.go
+++ b/application/state_machine_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ONSdigital/dis-bundle-api/apierrors"
 	"github.com/ONSdigital/dis-bundle-api/models"
+	"github.com/ONSdigital/dis-bundle-api/slack"
 	"github.com/ONSdigital/dis-bundle-api/store"
 	storetest "github.com/ONSdigital/dis-bundle-api/store/datastoretest"
 	datasetAPIModels "github.com/ONSdigital/dp-dataset-api/models"
@@ -143,7 +144,7 @@ func TestTransition_success(t *testing.T) {
 	mockPermissionsAPIClient := &permissionsAPISDKMock.ClienterMock{}
 	mockSlackClient := &slackMock.ClienterMock{}
 	stateMachine := NewStateMachine(ctx, states, transitions, store.Datastore{Backend: mockedDatastore})
-	stateMachineBundleAPI := Setup(store.Datastore{Backend: mockedDatastore}, stateMachine, mockDatasetAPIClient, mockPermissionsAPIClient, mockSlackClient)
+	stateMachineBundleAPI := Setup(store.Datastore{Backend: mockedDatastore}, stateMachine, mockDatasetAPIClient, mockPermissionsAPIClient, mockSlackClient, "")
 
 	Convey("When transitioning from 'DRAFT' to 'IN_REVIEW'", t, func() {
 		err := stateMachine.Transition(ctx, stateMachineBundleAPI, currentBundleWithStateDraft, bundleUpdateWithStateInReview)
@@ -221,7 +222,7 @@ func TestTransition_failure(t *testing.T) {
 	mockSlackClient := &slackMock.ClienterMock{}
 
 	stateMachine := NewStateMachine(ctx, states, transitions, store.Datastore{Backend: mockedDatastore})
-	stateMachineBundleAPI := Setup(store.Datastore{Backend: mockedDatastore}, stateMachine, mockDatasetAPIClient, mockPermissionsAPIClient, mockSlackClient)
+	stateMachineBundleAPI := Setup(store.Datastore{Backend: mockedDatastore}, stateMachine, mockDatasetAPIClient, mockPermissionsAPIClient, mockSlackClient, "")
 
 	Convey("When transitioning from a state that is not in the transition list", t, func() {
 		err := stateMachine.Transition(ctx, stateMachineBundleAPI, currentBundleWithStateUnknown, bundleUpdateWithStateInReview)
@@ -529,11 +530,12 @@ func TestTransitionBundle_Success(t *testing.T) {
 	mockSlackClient := &slackMock.ClienterMock{}
 
 	stateMachine := NewStateMachine(ctx, states, transitions, store.Datastore{Backend: mockedDatastore})
-	stateMachineBundleAPI := Setup(store.Datastore{Backend: mockedDatastore}, stateMachine, &mockdatasetAPIClient, mockPermissionsAPIClient, mockSlackClient)
-	bundle, err := stateMachine.TransitionBundle(ctx, stateMachineBundleAPI, mockBundle, &targetState, &mockAuthEntityData)
+	stateMachineBundleAPI := Setup(store.Datastore{Backend: mockedDatastore}, stateMachine, &mockdatasetAPIClient, mockPermissionsAPIClient, mockSlackClient, "")
+	bundle, hadContentItemFailures, err := stateMachine.TransitionBundle(ctx, stateMachineBundleAPI, mockBundle, &targetState, &mockAuthEntityData)
 
 	Convey("When TransitionBundle is called with a valid transition and valid bundle", t, func() {
 		So(err, ShouldBeNil)
+
 		Convey("Then the bundle should be updated", func() {
 			So(mockBundle.State.String(), ShouldEqual, targetState.String())
 			So(mockBundle.LastUpdatedBy.Email, ShouldEqual, mockUserID)
@@ -541,6 +543,10 @@ func TestTransitionBundle_Success(t *testing.T) {
 			Convey("And the returned bundle should match", func() {
 				So(mockBundle, ShouldEqual, bundle)
 			})
+		})
+
+		Convey("And hadContentItemFailures should be false", func() {
+			So(hadContentItemFailures, ShouldBeFalse)
 		})
 
 		contentItemsThatShouldBeUpdated := []*models.ContentItem{mockContentItems[0], mockContentItems[1]}
@@ -725,6 +731,7 @@ func TestTransitionBundle_Failure(t *testing.T) {
 
 		return errors.New("not found content item")
 	}
+
 	mockedDatastore := &storetest.StorerMock{
 		GetBundleContentsForBundleFunc: getBundleContentsFunc,
 		UpdateBundleFunc:               updateBundleFunc,
@@ -763,8 +770,8 @@ func TestTransitionBundle_Failure(t *testing.T) {
 		}
 
 		stateMachine := NewStateMachine(ctx, states, transitions, store.Datastore{Backend: mockedDatastore})
-		stateMachineBundleAPI := Setup(store.Datastore{Backend: mockedDatastore}, stateMachine, &mockdatasetAPIClient, mockPermissionsAPIClient, mockSlackClient)
-		bundle, err := stateMachine.TransitionBundle(ctx, stateMachineBundleAPI, mockBundle, &targetState, &mockAuthEntityData)
+		stateMachineBundleAPI := Setup(store.Datastore{Backend: mockedDatastore}, stateMachine, &mockdatasetAPIClient, mockPermissionsAPIClient, mockSlackClient, "")
+		bundle, _, err := stateMachine.TransitionBundle(ctx, stateMachineBundleAPI, mockBundle, &targetState, &mockAuthEntityData)
 		Convey("Then", t, func() {
 			Convey("the error should be returned", func() {
 				So(err, ShouldNotBeNil)
@@ -788,8 +795,8 @@ func TestTransitionBundle_Failure(t *testing.T) {
 		}
 
 		stateMachine := NewStateMachine(ctx, states, transitions, store.Datastore{Backend: mockedDatastore})
-		stateMachineBundleAPI := Setup(store.Datastore{Backend: mockedDatastore}, stateMachine, &mockdatasetAPIClient, mockPermissionsAPIClient, mockSlackClient)
-		bundle, err := stateMachine.TransitionBundle(ctx, stateMachineBundleAPI, mockBundle, &targetState, &mockAuthEntityData)
+		stateMachineBundleAPI := Setup(store.Datastore{Backend: mockedDatastore}, stateMachine, &mockdatasetAPIClient, mockPermissionsAPIClient, mockSlackClient, "")
+		bundle, _, err := stateMachine.TransitionBundle(ctx, stateMachineBundleAPI, mockBundle, &targetState, &mockAuthEntityData)
 		Convey("Then", t, func() {
 			Convey("Then a not found error should be returned", func() {
 				So(err, ShouldNotBeNil)
@@ -815,11 +822,11 @@ func TestTransitionBundle_Failure(t *testing.T) {
 		}
 
 		stateMachine := NewStateMachine(ctx, states, transitions, store.Datastore{Backend: mockedDatastore})
-		stateMachineBundleAPI := Setup(store.Datastore{Backend: mockedDatastore}, stateMachine, &mockdatasetAPIClient, mockPermissionsAPIClient, mockSlackClient)
+		stateMachineBundleAPI := Setup(store.Datastore{Backend: mockedDatastore}, stateMachine, &mockdatasetAPIClient, mockPermissionsAPIClient, mockSlackClient, "")
 
 		bundleInstance := *mockBundle
 
-		bundle, err := stateMachine.TransitionBundle(ctx, stateMachineBundleAPI, &bundleInstance, &targetState, &mockAuthEntityData)
+		bundle, _, err := stateMachine.TransitionBundle(ctx, stateMachineBundleAPI, &bundleInstance, &targetState, &mockAuthEntityData)
 		Convey("Then", t, func() {
 			Convey("the error should be returned", func() {
 				So(err, ShouldNotBeNil)
@@ -857,10 +864,10 @@ func TestTransitionBundle_Failure(t *testing.T) {
 		}
 
 		stateMachine := NewStateMachine(ctx, states, transitions, store.Datastore{Backend: mockedDatastore})
-		stateMachineBundleAPI := Setup(store.Datastore{Backend: mockedDatastore}, stateMachine, &mockdatasetAPIClient, mockPermissionsAPIClient, mockSlackClient)
+		stateMachineBundleAPI := Setup(store.Datastore{Backend: mockedDatastore}, stateMachine, &mockdatasetAPIClient, mockPermissionsAPIClient, mockSlackClient, "")
 
 		bundleInstance := *mockBundle
-		bundle, err := stateMachine.TransitionBundle(ctx, stateMachineBundleAPI, &bundleInstance, &targetState, &mockAuthEntityData)
+		bundle, _, err := stateMachine.TransitionBundle(ctx, stateMachineBundleAPI, &bundleInstance, &targetState, &mockAuthEntityData)
 		Convey("Then", t, func() {
 			Convey("the error should be returned", func() {
 				So(err, ShouldNotBeNil)
@@ -907,11 +914,15 @@ func TestTransitionBundle_Failure(t *testing.T) {
 			return nil
 		}
 
+		mockSlackClient.SendAlarmFunc = func(ctx context.Context, summary string, err error, fields []slack.Field) (*slack.MessageRef, error) {
+			return nil, nil
+		}
+
 		stateMachine := NewStateMachine(ctx, states, transitions, store.Datastore{Backend: mockedDatastore})
-		stateMachineBundleAPI := Setup(store.Datastore{Backend: mockedDatastore}, stateMachine, &mockdatasetAPIClient, mockPermissionsAPIClient, mockSlackClient)
+		stateMachineBundleAPI := Setup(store.Datastore{Backend: mockedDatastore}, stateMachine, &mockdatasetAPIClient, mockPermissionsAPIClient, mockSlackClient, "")
 
 		bundleInstance := *mockBundle
-		bundle, err := stateMachine.TransitionBundle(ctx, stateMachineBundleAPI, &bundleInstance, &targetState, &mockAuthEntityData)
+		bundle, hadContentItemFailures, err := stateMachine.TransitionBundle(ctx, stateMachineBundleAPI, &bundleInstance, &targetState, &mockAuthEntityData)
 
 		Convey("Then no error should be returned", t, func() {
 			So(err, ShouldBeNil)
@@ -922,6 +933,10 @@ func TestTransitionBundle_Failure(t *testing.T) {
 
 			Convey("And the bundle state should be updated to published", func() {
 				So(mockBundle.State.String(), ShouldEqual, targetState.String())
+			})
+
+			Convey("And hadContentItemFailures should be true", func() {
+				So(hadContentItemFailures, ShouldBeTrue)
 			})
 
 			Convey("And events should only be created for the successful content item and the bundle", func() {

--- a/config/config.go
+++ b/config/config.go
@@ -33,6 +33,7 @@ type Config struct {
 	EnablePermissionsAuth      bool          `envconfig:"ENABLE_PERMISSIONS_AUTH"`
 	ZebedeeURL                 string        `envconfig:"ZEBEDEE_URL"`
 	ZebedeeClientTimeout       time.Duration `envconfig:"ZEBEDEE_CLIENT_TIMEOUT"`
+	PreviewServiceURL          string        `envconfig:"PREVIEW_SERVICE_URL"`
 	MongoConfig
 	AuthConfig                                *authorisation.Config
 	DataBundlePublicationServiceSlackEnabled  bool   `envconfig:"DATA_BUNDLE_PUBLICATION_SERVICE_SLACK_ENABLED"`
@@ -70,6 +71,7 @@ func Get() (*Config, error) {
 		DefaultOffset:              0,
 		ZebedeeURL:                 "http://localhost:8082",
 		ZebedeeClientTimeout:       30 * time.Second,
+		PreviewServiceURL:          "",
 		MongoConfig: MongoConfig{
 			MongoDriverConfig: mongodriver.MongoDriverConfig{
 				ClusterEndpoint:               "localhost:27017",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -36,6 +36,7 @@ func TestSpec(t *testing.T) {
 				So(cfg.EnablePermissionsAuth, ShouldBeFalse)
 				So(cfg.ZebedeeURL, ShouldEqual, "http://localhost:8082")
 				So(cfg.ZebedeeClientTimeout, ShouldEqual, 30*time.Second)
+				So(cfg.PreviewServiceURL, ShouldEqual, "")
 
 				So(cfg.ClusterEndpoint, ShouldEqual, "localhost:27017")
 				So(cfg.Username, ShouldEqual, "")

--- a/service/service.go
+++ b/service/service.go
@@ -166,7 +166,7 @@ func (svc *Service) Run(ctx context.Context, buildTime, gitCommit, version strin
 
 	// Setup state machine
 	sm := GetStateMachine(ctx, datastore)
-	svc.stateMachineBundleAPI = application.Setup(datastore, sm, svc.datasetAPIClient, svc.permissionsAPIClient, svc.dataBundleSlackClient)
+	svc.stateMachineBundleAPI = application.Setup(datastore, sm, svc.datasetAPIClient, svc.permissionsAPIClient, svc.dataBundleSlackClient, cfg.PreviewServiceURL)
 
 	// Setup API
 	svc.API = api.Setup(ctx, svc.Config, r, &datastore, svc.stateMachineBundleAPI, authorisation, svc.ZebedeeClient.Client)

--- a/slack/client.go
+++ b/slack/client.go
@@ -60,6 +60,12 @@ func (c *Client) UpdatePublishLog(ctx context.Context, ref *MessageRef, summary 
 	return c.doUpdateMessage(ctx, ref, GreenColour, TickEmoji, summary, buildAttachmentFields(nil, fields))
 }
 
+// UpdatePublishLogAsAlarm updates a previously sent publish log message as a red alarm,
+// used when one or more content items failed to publish.
+func (c *Client) UpdatePublishLogAsAlarm(ctx context.Context, ref *MessageRef, summary string, fields []Field) (*MessageRef, error) {
+	return c.doUpdateMessage(ctx, ref, RedColour, AlarmEmoji, summary, buildAttachmentFields(nil, fields))
+}
+
 // doSendMessage is a helper function to send a message to a specified Slack channel with given parameters
 func (c *Client) doSendMessage(ctx context.Context, channel string, color Colour, emoji Emoji, summary string, fields []slack.AttachmentField) (*MessageRef, error) {
 	attachment := slack.Attachment{

--- a/slack/client_test.go
+++ b/slack/client_test.go
@@ -191,7 +191,7 @@ func TestClient_DoSendMessage(t *testing.T) {
 	})
 }
 
-// This test covers the doUpdateMessage method indirectly through UpdatePublishLog.
+// This test covers the doUpdateMessage method indirectly through UpdatePublishLog and UpdatePublishLogAsAlarm.
 // It verifies that message updates can be sent to Slack without errors and uses a mock HTTP server to simulate Slack's API.
 func TestClient_DoUpdateMessage(t *testing.T) {
 	Convey("Given a mock Slack Client and valid parameters", t, func() {
@@ -213,6 +213,17 @@ func TestClient_DoUpdateMessage(t *testing.T) {
 
 		Convey("When doUpdateMessage is called through UpdatePublishLog", func() {
 			updatedRef, err := client.UpdatePublishLog(context.Background(), ref, "Updated Summary", []Field{{Title: "key", Value: "value"}})
+
+			Convey("Then no error is returned", func() {
+				So(err, ShouldBeNil)
+				So(updatedRef, ShouldNotBeNil)
+				So(updatedRef.ChannelID, ShouldEqual, "test-channel")
+				So(updatedRef.Timestamp, ShouldEqual, "1234.5678")
+			})
+		})
+
+		Convey("When doUpdateMessage is called through UpdatePublishLogAsAlarm", func() {
+			updatedRef, err := client.UpdatePublishLogAsAlarm(context.Background(), ref, "Updated Summary", []Field{{Title: "key", Value: "value"}})
 
 			Convey("Then no error is returned", func() {
 				So(err, ShouldBeNil)
@@ -252,6 +263,16 @@ func TestClient_DoUpdateMessage(t *testing.T) {
 				So(err.Error(), ShouldContainSubstring, "failed to update message in Slack channel")
 			})
 		})
+
+		Convey("When UpdatePublishLogAsAlarm is called", func() {
+			updatedRef, err := client.UpdatePublishLogAsAlarm(context.Background(), ref, "Updated Summary", nil)
+
+			Convey("Then a wrapped error is returned", func() {
+				So(updatedRef, ShouldBeNil)
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldContainSubstring, "failed to update message in Slack channel")
+			})
+		})
 	})
 
 	Convey("Given invalid message references", t, func() {
@@ -277,6 +298,33 @@ func TestClient_DoUpdateMessage(t *testing.T) {
 
 		Convey("When UpdatePublishLog is called with an empty timestamp", func() {
 			updatedRef, err := client.UpdatePublishLog(context.Background(), &MessageRef{ChannelID: "test-channel"}, "Updated Summary", nil)
+
+			Convey("Then a missing timestamp error is returned", func() {
+				So(err, ShouldEqual, errMissingMessageRefTimestamp)
+				So(updatedRef, ShouldBeNil)
+			})
+		})
+
+		Convey("When UpdatePublishLogAsAlarm is called with a nil ref", func() {
+			updatedRef, err := client.UpdatePublishLogAsAlarm(context.Background(), nil, "Updated Summary", nil)
+
+			Convey("Then a missing ref error is returned", func() {
+				So(err, ShouldEqual, errMissingMessageRef)
+				So(updatedRef, ShouldBeNil)
+			})
+		})
+
+		Convey("When UpdatePublishLogAsAlarm is called with an empty channel", func() {
+			updatedRef, err := client.UpdatePublishLogAsAlarm(context.Background(), &MessageRef{Timestamp: "1234.5678"}, "Updated Summary", nil)
+
+			Convey("Then a missing channel error is returned", func() {
+				So(err, ShouldEqual, errMissingMessageRefChannel)
+				So(updatedRef, ShouldBeNil)
+			})
+		})
+
+		Convey("When UpdatePublishLogAsAlarm is called with an empty timestamp", func() {
+			updatedRef, err := client.UpdatePublishLogAsAlarm(context.Background(), &MessageRef{ChannelID: "test-channel"}, "Updated Summary", nil)
 
 			Convey("Then a missing timestamp error is returned", func() {
 				So(err, ShouldEqual, errMissingMessageRefTimestamp)

--- a/slack/interface.go
+++ b/slack/interface.go
@@ -13,4 +13,5 @@ type Clienter interface {
 	SendInfo(ctx context.Context, summary string, fields []Field) (*MessageRef, error)
 	SendPublishLog(ctx context.Context, summary string, fields []Field) (*MessageRef, error)
 	UpdatePublishLog(ctx context.Context, ref *MessageRef, summary string, fields []Field) (*MessageRef, error)
+	UpdatePublishLogAsAlarm(ctx context.Context, ref *MessageRef, summary string, fields []Field) (*MessageRef, error)
 }

--- a/slack/mocks/client.go
+++ b/slack/mocks/client.go
@@ -34,6 +34,9 @@ var _ slack.Clienter = &ClienterMock{}
 //			UpdatePublishLogFunc: func(ctx context.Context, ref *slack.MessageRef, summary string, fields []slack.Field) (*slack.MessageRef, error) {
 //				panic("mock out the UpdatePublishLog method")
 //			},
+//			UpdatePublishLogAsAlarmFunc: func(ctx context.Context, ref *slack.MessageRef, summary string, fields []slack.Field) (*slack.MessageRef, error) {
+//				panic("mock out the UpdatePublishLogAsAlarm method")
+//			},
 //		}
 //
 //		// use mockedClienter in code that requires slack.Clienter
@@ -55,6 +58,9 @@ type ClienterMock struct {
 
 	// UpdatePublishLogFunc mocks the UpdatePublishLog method.
 	UpdatePublishLogFunc func(ctx context.Context, ref *slack.MessageRef, summary string, fields []slack.Field) (*slack.MessageRef, error)
+
+	// UpdatePublishLogAsAlarmFunc mocks the UpdatePublishLogAsAlarm method.
+	UpdatePublishLogAsAlarmFunc func(ctx context.Context, ref *slack.MessageRef, summary string, fields []slack.Field) (*slack.MessageRef, error)
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -107,12 +113,24 @@ type ClienterMock struct {
 			// Fields is the fields argument value.
 			Fields []slack.Field
 		}
+		// UpdatePublishLogAsAlarm holds details about calls to the UpdatePublishLogAsAlarm method.
+		UpdatePublishLogAsAlarm []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// Ref is the ref argument value.
+			Ref *slack.MessageRef
+			// Summary is the summary argument value.
+			Summary string
+			// Fields is the fields argument value.
+			Fields []slack.Field
+		}
 	}
-	lockSendAlarm        sync.RWMutex
-	lockSendInfo         sync.RWMutex
-	lockSendPublishLog   sync.RWMutex
-	lockSendWarning      sync.RWMutex
-	lockUpdatePublishLog sync.RWMutex
+	lockSendAlarm               sync.RWMutex
+	lockSendInfo                sync.RWMutex
+	lockSendPublishLog          sync.RWMutex
+	lockSendWarning             sync.RWMutex
+	lockUpdatePublishLog        sync.RWMutex
+	lockUpdatePublishLogAsAlarm sync.RWMutex
 }
 
 // SendAlarm calls SendAlarmFunc.
@@ -320,5 +338,49 @@ func (mock *ClienterMock) UpdatePublishLogCalls() []struct {
 	mock.lockUpdatePublishLog.RLock()
 	calls = mock.calls.UpdatePublishLog
 	mock.lockUpdatePublishLog.RUnlock()
+	return calls
+}
+
+// UpdatePublishLogAsAlarm calls UpdatePublishLogAsAlarmFunc.
+func (mock *ClienterMock) UpdatePublishLogAsAlarm(ctx context.Context, ref *slack.MessageRef, summary string, fields []slack.Field) (*slack.MessageRef, error) {
+	if mock.UpdatePublishLogAsAlarmFunc == nil {
+		panic("ClienterMock.UpdatePublishLogAsAlarmFunc: method is nil but Clienter.UpdatePublishLogAsAlarm was just called")
+	}
+	callInfo := struct {
+		Ctx     context.Context
+		Ref     *slack.MessageRef
+		Summary string
+		Fields  []slack.Field
+	}{
+		Ctx:     ctx,
+		Ref:     ref,
+		Summary: summary,
+		Fields:  fields,
+	}
+	mock.lockUpdatePublishLogAsAlarm.Lock()
+	mock.calls.UpdatePublishLogAsAlarm = append(mock.calls.UpdatePublishLogAsAlarm, callInfo)
+	mock.lockUpdatePublishLogAsAlarm.Unlock()
+	return mock.UpdatePublishLogAsAlarmFunc(ctx, ref, summary, fields)
+}
+
+// UpdatePublishLogAsAlarmCalls gets all the calls that were made to UpdatePublishLogAsAlarm.
+// Check the length with:
+//
+//	len(mockedClienter.UpdatePublishLogAsAlarmCalls())
+func (mock *ClienterMock) UpdatePublishLogAsAlarmCalls() []struct {
+	Ctx     context.Context
+	Ref     *slack.MessageRef
+	Summary string
+	Fields  []slack.Field
+} {
+	var calls []struct {
+		Ctx     context.Context
+		Ref     *slack.MessageRef
+		Summary string
+		Fields  []slack.Field
+	}
+	mock.lockUpdatePublishLogAsAlarm.RLock()
+	calls = mock.calls.UpdatePublishLogAsAlarm
+	mock.lockUpdatePublishLogAsAlarm.RUnlock()
 	return calls
 }

--- a/slack/noop_client.go
+++ b/slack/noop_client.go
@@ -24,3 +24,7 @@ func (n *NoopClient) SendPublishLog(ctx context.Context, summary string, fields 
 func (n *NoopClient) UpdatePublishLog(ctx context.Context, ref *MessageRef, summary string, fields []Field) (*MessageRef, error) {
 	return nil, nil
 }
+
+func (n *NoopClient) UpdatePublishLogAsAlarm(ctx context.Context, ref *MessageRef, summary string, fields []Field) (*MessageRef, error) {
+	return nil, nil
+}

--- a/slack/noop_client_test.go
+++ b/slack/noop_client_test.go
@@ -83,3 +83,18 @@ func TestNoopClient_UpdatePublishLog(t *testing.T) {
 		})
 	})
 }
+
+func TestNoopClient_UpdatePublishLogAsAlarm(t *testing.T) {
+	Convey("Given a NoopClient", t, func() {
+		client := &slack.NoopClient{}
+
+		Convey("When UpdatePublishLogAsAlarm is called", func() {
+			ref, err := client.UpdatePublishLogAsAlarm(context.Background(), &slack.MessageRef{ChannelID: "test-channel", Timestamp: "1234567890.123456"}, "Test Summary", nil)
+
+			Convey("Then no error is returned", func() {
+				So(err, ShouldBeNil)
+				So(ref, ShouldBeNil)
+			})
+		})
+	})
+}


### PR DESCRIPTION
### What

Update Slack notifications on bundle publication if a content item errors
Jira - https://officefornationalstatistics.atlassian.net/browse/DIS-4786

### How to review

To test locally:

- create a bundle and add two dataset content items
- move the bundle through the states to `APPROVED`
- delete the version for the one of the content items
- transition the bundle to `PUBLISHED` state
- check the bundle api logs. You should see - 

`"sending slack notification: Bundle publish started"` with the correct fields

`"Error occurred transitioning content item for bundle: version not found"` for the deleted version

`"sending slack alarm for content item failure"` with all the expected alarm fields (bundle ID, bundle title, dataset ID, edition, version, preview link)

`"updating slack notification: Bundle publish completed with errors"` confirming the initial message would be updated to red

`"putBundleState endpoint: request successful"` with a `200` confirming the bundle still published despite the failure

To verify the actual Slack message appearance (red colour, alarm emoji, correct fields in the right channel) this will need to be tested in sandbox after approval

### Who can review

Anyone
