### PR TITLE
update preview link url

### DIFF
--- a/application/state_machine.go
+++ b/application/state_machine.go
@@ -165,12 +165,7 @@ func (sm *StateMachine) TransitionBundle(ctx context.Context, stateMachineBundle
 			if err != nil {
 				log.Warn(ctx, fmt.Sprintf("Error occurred transitioning content item for bundle: %s", err.Error()), log.Data{"bundle-id": bundle.ID, "content-item-id": contentItem.ID})
 
-				previewURL := fmt.Sprintf("%s/datasets/%s/editions/%s/versions/%s",
-					stateMachineBundleAPI.PreviewServiceURL,
-					contentItem.Metadata.DatasetID,
-					contentItem.Metadata.EditionID,
-					strconv.Itoa(contentItem.Metadata.VersionID),
-				)
+				previewURL := stateMachineBundleAPI.PreviewServiceURL + contentItem.Links.Preview
 
 				alarmFields := []slack.Field{
 					{Title: "Bundle ID", Value: bundle.ID},

--- a/application/state_machine_test.go
+++ b/application/state_machine_test.go
@@ -897,6 +897,10 @@ func TestTransitionBundle_Failure(t *testing.T) {
 			mockContentItems[index].State = &state
 		}
 
+		mockContentItems[0].Links = models.Links{
+			Preview: "/economy/datasets/dataset-id-1/editions/edition-id-1/versions/1",
+		}
+
 		mockedDatastore.GetBundleContentsForBundleFunc = getBundleContentsFunc
 		mockedDatastore.UpdateBundleFunc = updateBundleFunc
 		mockedDatastore.CreateEventFunc = createEventFunc


### PR DESCRIPTION
### What

Small update to this PR - https://github.com/ONSdigital/dis-bundle-api/pull/138
Updated preview link URL construction to include topic slug at the start of the URL. Changed from manually building the URL using dataset/edition/version to using PreviewServiceURL + contentItem.Links.Preview, as the stored preview link already contains the full path including the topic slug

### How to review

Confirm change makes sense, tests pass

### Who can review

Anyone
