### PR TITLE
Resolve issue with bundle publication failure slack notification

### DIFF
--- a/application/application.go
+++ b/application/application.go
@@ -643,7 +643,9 @@ func PublishBundle(ctx context.Context, smBundle StateMachineBundleAPI, bundle *
 	wg.Wait()
 
 	close(errCh)
+	var contentItemErr error
 	for err := range errCh {
+		contentItemErr = err
 		log.Error(ctx, "something went wrong when processing content items", err, logData)
 	}
 
@@ -666,10 +668,18 @@ func PublishBundle(ctx context.Context, smBundle StateMachineBundleAPI, bundle *
 	)
 	logData["slack_fields"] = publishLogFields
 
-	log.Info(ctx, "updating slack notification: Bundle publish completed", logData)
-	_, alarmErr := smBundle.DataBundleSlackClient.UpdatePublishLog(ctx, slackMessageRef, "Bundle publish completed", publishLogFields)
-	if alarmErr != nil {
-		log.Error(ctx, "failed to send slack notification: Bundle publish completed", alarmErr, logData)
+	if contentItemErr != nil {
+		log.Info(ctx, "updating slack notification: Bundle publish completed with errors", logData)
+		_, err = smBundle.DataBundleSlackClient.UpdatePublishLogAsAlarm(ctx, slackMessageRef, "Bundle publish completed with errors", publishLogFields)
+		if err != nil {
+			log.Error(ctx, "failed to update slack notification: Bundle publish completed with errors", err, logData)
+		}
+	} else {
+		log.Info(ctx, "updating slack notification: Bundle publish completed", logData)
+		_, alarmErr := smBundle.DataBundleSlackClient.UpdatePublishLog(ctx, slackMessageRef, "Bundle publish completed", publishLogFields)
+		if alarmErr != nil {
+			log.Error(ctx, "failed to send slack notification: Bundle publish completed", alarmErr, logData)
+		}
 	}
 
 	identityType := log.USER

--- a/application/application_test.go
+++ b/application/application_test.go
@@ -1810,10 +1810,13 @@ func TestPutBundleState_ContentItemFails(t *testing.T) {
 					Timestamp: "example-timestamp",
 				}, nil
 			},
-			UpdatePublishLogFunc: func(ctx context.Context, ref *slack.MessageRef, summary string, fields []slack.Field) (*slack.MessageRef, error) {
-				return &slack.MessageRef{}, nil
-			},
 			SendAlarmFunc: func(ctx context.Context, summary string, err error, fields []slack.Field) (*slack.MessageRef, error) {
+				return &slack.MessageRef{
+					ChannelID: "example-channel",
+					Timestamp: "example-timestamp",
+				}, nil
+			},
+			UpdatePublishLogAsAlarmFunc: func(ctx context.Context, ref *slack.MessageRef, summary string, fields []slack.Field) (*slack.MessageRef, error) {
 				return &slack.MessageRef{
 					ChannelID: "example-channel",
 					Timestamp: "example-timestamp",
@@ -1837,7 +1840,7 @@ func TestPutBundleState_ContentItemFails(t *testing.T) {
 				So(len(mockedDatastore.UpdateBundleCalls()), ShouldEqual, 1)
 				So(len(mockedDatastore.CreateEventCalls()), ShouldEqual, 1)
 				So(len(mockSlackClient.SendPublishLogCalls()), ShouldEqual, 1)
-				So(len(mockSlackClient.UpdatePublishLogCalls()), ShouldEqual, 1)
+				So(len(mockSlackClient.UpdatePublishLogAsAlarmCalls()), ShouldEqual, 1)
 				So(len(mockSlackClient.SendAlarmCalls()), ShouldEqual, 2)
 			})
 		})


### PR DESCRIPTION
### What

While testing in staging it was noticed that if a bundle content item failed to publish, then the associated overall slack notification for the bundle was not indicating there was a problem - it was still green and not notifying of the failure.

This has now been fixed.

### How to review

Ensure the tests pass and the changes make sense.  For a more detailed review, run the dataset catalogue stack and create a version for a series.  Ensure that the path to the distribution file included in the version does not exist. Add the version to a bundle and progress through to publication.  There should be information in the logs indicating that a slack notification has been updated with the message "Bundle publish completed with errors".

### Who can review

Anyone.
