### PR TITLE
bump to go 1.26.4

### DIFF
--- a/ci/audit.yml
+++ b/ci/audit.yml
@@ -5,7 +5,7 @@ image_resource:
   type: docker-image
   source:
     repository: onsdigital/dp-concourse-tools-vulncheck
-    tag: 1.26.3-vulncheck-0.5.0
+    tag: 1.26.4-vulncheck-0.5.0
 
 inputs:
   - name: dis-bundle-api

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.26.3-bookworm
+    tag: 1.26.4-bookworm
 
 inputs:
   - name: dis-bundle-api

--- a/ci/component.yml
+++ b/ci/component.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: onsdigital/dp-concourse-tools-docker-go
-    tag: 1.26.3-dind-28
+    tag: 1.26.4-dind-28
 
 inputs:
   - name: dis-bundle-api

--- a/ci/lint.yml
+++ b/ci/lint.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: onsdigital/dp-concourse-tools-lint-go
-    tag: 1.26.3-bookworm-golangci-lint-2
+    tag: 1.26.4-bookworm-golangci-lint-2
 
 inputs:
   - name: dis-bundle-api

--- a/ci/unit.yml
+++ b/ci/unit.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: onsdigital/dp-concourse-tools-docker-go
-    tag: 1.26.3-dind-28
+    tag: 1.26.4-dind-28
 
 inputs:
   - name: dis-bundle-api


### PR DESCRIPTION
### What

- Bump to Go `1.26.4` to resolve audit failures

### How to review

- Check changes are ok

### Who can review

- Anyone